### PR TITLE
Remove warning, should ==

### DIFF
--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -39,7 +39,7 @@ describe Rack::Test::Session do
     it "deletes cookies directly from the CookieJar" do
       jar = Rack::Test::CookieJar.new
       jar["abcd"] = "1234"
-      jar["abcd"].should == "1234"
+      jar["abcd"].should eq "1234"
       jar.delete("abcd")
       jar["abcd"].should == nil
     end
@@ -130,7 +130,7 @@ describe Rack::Test::Session do
       check last_request.cookies.should == {}
 
       get "https://example.com/cookies/show"
-      last_request.cookies.should == { "secure-cookie" => "set" }
+      last_request.cookies.should eq({ "secure-cookie" => "set" })
       rack_mock_session.cookie_jar['secure-cookie'].should == 'set'
     end
 
@@ -150,7 +150,7 @@ describe Rack::Test::Session do
     it "keeps one cookie jar for domain and its subdomains" do
       get "http://example.org/cookies/subdomain"
       get "http://example.org/cookies/subdomain"
-      last_request.cookies.should == { "count" => "1" }
+      last_request.cookies.should eq({ "count" => "1" })
 
       get "http://foo.example.org/cookies/subdomain"
       last_request.cookies.should == { "count" => "2" }

--- a/spec/rack/test/multipart_spec.rb
+++ b/spec/rack/test/multipart_spec.rb
@@ -53,7 +53,7 @@ describe Rack::Test::Session do
 
     it "sends params encoded as ISO-8859-1" do
       post "/", "photo" => uploaded_file, "foo" => "bar", "utf8" => "☃"
-      last_request.POST["foo"].should == "bar"
+      last_request.POST["foo"].should eq "bar"
 
       if Rack::Test.encoding_aware_strings?
         last_request.POST["utf8"].should == "☃"

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -81,7 +81,7 @@ describe Rack::Test::Utils do
       check params["submit-name"].should == "Larry"
 
       check params["files"][0][:filename].should == "foo.txt"
-      params["files"][0][:tempfile].read.should == "bar\n"
+      params["files"][0][:tempfile].read.should eq "bar\n"
 
       check params["files"][1][:filename].should == "bar.txt"
       params["files"][1][:tempfile].read.should == "baz\n"
@@ -100,7 +100,7 @@ describe Rack::Test::Utils do
       params = Rack::Utils::Multipart.parse_multipart(env)
       check params["people"][0]["submit-name"].should == "Larry"
       check params["people"][0]["files"][:filename].should == "foo.txt"
-      params["people"][0]["files"][:tempfile].read.should == "bar\n"
+      params["people"][0]["files"][:tempfile].read.should eq "bar\n"
       check params["foo"].should == ["1", "2"]
     end
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -36,23 +36,23 @@ describe Rack::Test::Session do
 
     it "sets HTTP_HOST with port for non-default ports" do
       request "http://foo.com:8080"
-      last_request.env["HTTP_HOST"].should == "foo.com:8080"
+      last_request.env["HTTP_HOST"].should eq "foo.com:8080"
       request "https://foo.com:8443"
       last_request.env["HTTP_HOST"].should == "foo.com:8443"
     end
 
     it "sets HTTP_HOST without port for default ports" do
       request "http://foo.com"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      last_request.env["HTTP_HOST"].should eq "foo.com"
       request "http://foo.com:80"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      last_request.env["HTTP_HOST"].should eq "foo.com"
       request "https://foo.com:443"
-      last_request.env["HTTP_HOST"].should == "foo.com"
+      last_request.env["HTTP_HOST"].should eq "foo.com"
     end
 
     it "defaults to GET" do
       request "/"
-      last_request.env["REQUEST_METHOD"].should == "GET"
+      last_request.env["REQUEST_METHOD"].should eq "GET"
     end
 
     it "defaults the REMOTE_ADDR to 127.0.0.1" do
@@ -229,7 +229,7 @@ describe Rack::Test::Session do
     context "for a XHR" do
       it "sends XMLHttpRequest for the X-Requested-With header" do
         request "/", :xhr => true
-        last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
+        last_request.env["HTTP_X_REQUESTED_WITH"].should eq "XMLHttpRequest"
         last_request.should be_xhr
       end
     end
@@ -312,7 +312,7 @@ describe Rack::Test::Session do
       follow_redirect!
 
       last_response.should_not be_redirect
-      last_response.body.should == "You've been redirected"
+      last_response.body.should eq "You've been redirected"
       last_request.env["HTTP_REFERER"].should eql("http://example.org/redirect")
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,7 @@ shared_examples_for "any #verb methods" do
   context "for a XHR" do
     it "sends XMLHttpRequest for the X-Requested-With header" do
       send(verb, "/", {}, { :xhr => true })
-      last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
+      last_request.env["HTTP_X_REQUESTED_WITH"].should eq "XMLHttpRequest"
       last_request.should be_xhr
     end
   end


### PR DESCRIPTION
warning: possibly useless use of == in void context
