### PR TITLE
Prevent truncation of path to empty string when Path attribute is not specified

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -22,7 +22,16 @@ module Rack
         @options = parse_query(options, ';')
 
         @options["domain"]  ||= (uri.host || default_host)
-        @options["path"]    ||= uri.path.sub(/\/[^\/]*\Z/, "")
+
+        unless @options.has_key?("path")
+          # http://tools.ietf.org/html/rfc6265#section-5.1.4
+          if uri.path.empty? || uri.path[0] != '/' || uri.path.count('/') < 2
+            @options["path"] = '/'
+          else
+            # the uri-path from the first character up to, but not including, the right-most %x2F ("/")
+            @options["path"] = uri.path.sub(/\/[^\/]*\Z/, "")
+          end
+        end
       end
 
       def replaces?(other)

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -29,6 +29,18 @@ module Rack
         [200, {}, ""]
       end
 
+      get "/cookies-set-default-path" do
+        raise if params["value"].nil?
+
+        response.set_cookie "default", :value => params["value"]
+      end
+
+      get "/cookies-set-forced-path" do
+        raise if params["value"].nil?
+
+        response.set_cookie "default", :value => params["value"], :path => '/'
+      end
+
       get "/cookies/show" do
         request.cookies.inspect
       end
@@ -60,10 +72,6 @@ module Rack
 
         response.set_cookie "simple", params["value"]
         "Set"
-      end
-
-      get "/cookies/default-path" do
-        response.cookies.inspect
       end
 
       get "/cookies/delete" do

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -20,16 +20,6 @@ describe Rack::Test::Session do
       last_request.cookies.should == {}
     end
 
-    it "cookie path defaults to the uri of the document that was requested" do
-      pending "See issue rack-test github issue #50" do
-        post "/cookies/default-path", "value" => "cookie"
-        get "/cookies/default-path"
-        check last_request.cookies.should == { "simple"=>"cookie" }
-        get "/cookies/show"
-        check last_request.cookies.should == { }
-      end
-    end
-
     it "escapes cookie values" do
       jar = Rack::Test::CookieJar.new
       jar["value"] = "foo;abc"
@@ -118,10 +108,16 @@ describe Rack::Test::Session do
       last_request.cookies.should == {}
     end
 
-    it "defaults the domain to the request path up to the last slash" do
+    it "defaults the path to the request path up to the last slash" do
       get "/cookies/set-simple", "value" => "1"
       get "/not-cookies/show"
       last_request.cookies.should == {}
+    end
+
+    it "defaults the path to '/' when request path is in the root directory" do
+      get "/cookies-set-forced-path", "value" => "1"
+      get "/cookies-set-default-path", "value" => "2"
+      rack_mock_session.cookie_jar['default'].should == "2"
     end
 
     it "supports secure cookies" do


### PR DESCRIPTION
This is a (hopefully) clearer version of pull request https://github.com/brynary/rack-test/pull/53 which, given your comments, was a little confusing.  It is intended to resolve issue https://github.com/brynary/rack-test/issues/50.

To recap the issue since it's been so long:

In my test I do this:
  rack_mock_session.cookie_jar['my_auth_cookie'] = 'blah'

This mimics a user tampering with their cookie - I want to ensure that our system rejects the modified cookie.

Due to the way CookieJar#[]= uses it's merge method to replace the existing cookie, and merge creates new cookies with @default_host, the new cookies are created with an apparent uri-path of '/'.

https://github.com/brynary/rack-test/blob/master/lib/rack/test/cookie_jar.rb#L25 was incorrectly truncating '/' to a final cookie path of '' (empty string).

The intention of that regexp is to implement item 4 of http://tools.ietf.org/html/rfc6265#section-5.1.4.

But it neglects to handle item 2, when the uri-path is '/'. Instead of preserving it as '/' the regexp converts it into '' (empty string).

Since it's quite a subtle bug I decided to re-write that regexp into a few lines of code that almost exactly mirror the structure & wording of the RFC, and I added tests for that specific case.
