### PR TITLE
Long Basic auth header gets corrupted with a line break

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -145,7 +145,8 @@ module Rack
       # Example:
       #   basic_authorize "bryan", "secret"
       def basic_authorize(username, password)
-        encoded_login = ["#{username}:#{password}"].pack("m*")
+        require 'base64'
+        encoded_login = Base64.strict_encode64(["#{username}:#{password}"].join)
         header('Authorization', "Basic #{encoded_login}")
       end
 


### PR DESCRIPTION
Use strict_encode64 to avoid line breaks in the header
