### PR TITLE
Added functionality to mock session values in tests

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -154,6 +154,16 @@ module Rack
         end
       end
 
+      # Gets the current session hash
+      def rack_session
+        @rack_session ||= {}
+      end
+
+      # Sets the current session data
+      def rack_session=(hash)
+        @rack_session = hash
+      end
+
       # Set the username and password for HTTP Basic authorization, to be
       # included in subsequent requests in the HTTP_AUTHORIZATION header.
       #
@@ -237,6 +247,8 @@ module Rack
         if env.has_key?(:cookie)
           set_cookie(env.delete(:cookie), uri)
         end
+
+        env.merge!({'rack.session' => rack_session})
 
         Rack::MockRequest.env_for(uri.to_s, env)
       end

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -133,6 +133,14 @@ module Rack
         "Set"
       end
 
+      get "/session" do
+        session.inspect
+      end
+
+      get "/session/set" do
+        session[params[:key].to_sym] = params[:value]
+      end
+
       post "/" do
         "Hello, POST: #{params.inspect}"
       end

--- a/spec/rack/test/rack_session_spec.rb
+++ b/spec/rack/test/rack_session_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Rack::Test::Session do
+  after :each do
+    # current_session.rack_session = nil
+  end
+
+  it "allows setting session via env" do
+    current_session.rack_session[:user_id] = "1337"
+    get "/session"
+    last_response.body.to_s.should == '{:user_id=>"1337"}'
+    current_session.rack_session = nil
+  end
+
+  pending "makes the session data readable via env" do
+    # TODO: Not sure this is actually desired functionality, since you probably shouldn't be asserting on this stuff in tests
+    get "/session/set", :key => :foo, :value => 42
+    current_session.rack_session.should == { :foo => "42" }
+  end
+
+end


### PR DESCRIPTION
This patch allows one to set a session variable in a test case. Useful for bypassing authentication etc.
