### PR TITLE
Don't clobber request query string when passing params

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rspec/core'
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new do |t|
-  t.pattern = "./**/*_spec.rb"
+  t.pattern = "spec/**/*_spec.rb"
   t.ruby_opts = "-w"
 end
 

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -209,8 +209,8 @@ module Rack
           # merge :params with the query string
           if params = env[:params]
             params = parse_nested_query(params) if params.is_a?(String)
-            params.update(parse_nested_query(uri.query))
-            uri.query = build_nested_query(params)
+
+            uri.query = [uri.query, build_nested_query(params)].compact.join("&")
           end
         elsif !env.has_key?(:input)
           env["CONTENT_TYPE"] ||= "application/x-www-form-urlencoded"

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -127,6 +127,11 @@ describe Rack::Test::Session do
       last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5+%20"
     end
 
+    it "does not overwrite multiple query string keys" do
+      request "/foo?a=1&a=2", :params => { :bar => 1 }
+      last_request.query_string.should == "a=1&a=2&bar=1"
+    end
+
     it "accepts params and builds url encoded params for POST requests" do
       request "/foo", :method => :post, :params => {:foo => {:bar => "1"}}
       last_request.env["rack.input"].read.should == "foo[bar]=1"


### PR DESCRIPTION
I'm dealing with an API that requires the same query string key be passed multiple times. Normally Rack will parse the params and the last duplicate pair will win, but you can still parse the query string yourself if necessary. In certain cases in rack-test the query string is rebuilt from the parsed params which loses the duplicate keys altogether. This patch should fix that. Let me know if you have any questions.

Thanks!
