### PR TITLE
Fix warning

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -35,6 +35,7 @@ module Rack
       # (See README.rdoc for an example)
       def initialize(mock_session)
         @headers = {}
+        @digest_username = nil
 
         if mock_session.is_a?(MockSession)
           @rack_mock_session = mock_session


### PR DESCRIPTION
When Session#digest_auth_configured? is called:

    warning: instance variable @digest_username not initialized
