### PR TITLE
Add support for LINK and UNLINK verbs

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -112,6 +112,24 @@ module Rack
         process_request(uri, env, &block)
       end
 
+      # Issue a LINK request for the given URI. See #get
+      #
+      # Example:
+      #   link "/"
+      def link(uri, params = {}, env = {}, &block)
+        env = env_for(uri, env.merge(:method => "LINK", :params => params))
+        process_request(uri, env, &block)
+      end
+
+      # Issue an UNLINK request for the given URI. See #get
+      #
+      # Example:
+      #   unlink "/"
+      def unlink(uri, params = {}, env = {}, &block)
+        env = env_for(uri, env.merge(:method => "UNLINK", :params => params))
+        process_request(uri, env, &block)
+      end
+
       # Issue a request to the Rack app for the given URI and optional Rack
       # environment. Stores the issues request object in #last_request and
       # the app's response in #last_response. Yield #last_response to a block

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -65,6 +65,8 @@ module Rack
         :delete,
         :options,
         :head,
+        :link,
+        :unlink,
         :follow_redirect!,
         :header,
         :env,

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -137,6 +137,14 @@ module Rack
       delete "/" do
         "Hello, DELETE: #{params.inspect}"
       end
+
+      link "/" do
+        "Hello, LINK: #{params.inspect}"
+      end
+
+      unlink "/" do
+        "Hello, UNLINK: #{params.inspect}"
+      end
     end
 
   end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -547,4 +547,20 @@ describe Rack::Test::Session do
       "options"
     end
   end
+
+  describe "#link" do
+    it_should_behave_like "any #verb methods"
+
+    def verb
+      "link"
+    end
+  end
+
+  describe "#unlink" do
+    it_should_behave_like "any #verb methods"
+
+    def verb
+      "unlink"
+    end
+  end
 end


### PR DESCRIPTION
Sinatra has added direct support for LINK and UNLINK. This commit
adds support for those verbs.
