### PR TITLE
Don't recommend installing gem with sudo

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,7 +61,7 @@ If you want to test one app in isolation, you just return that app as shown abov
 
 To install the latest release as a gem:
 
-  sudo gem install rack-test
+  gem install rack-test
 
 Or via Bundler:
 


### PR DESCRIPTION
Since gems can execute arbitrary code, installing with sudo [can get dangerous](https://github.com/wmorgan/killergem) if anyone manages to hijack this gem or one if it's dependencies on RubyGems.

If a user _wants_ to install with sudo, they certainly can, and then they are assuming all the risk by being explicit. But it should not be recommended.

See also: http://masanjin.net/blog/sudo-gem-install-considered-harmful
