### PR TITLE
Handle multiple 'path' values for Cookie

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -50,7 +50,7 @@ module Rack
 
       # :api: private
       def path
-        @options["path"].strip || "/"
+        ([*@options["path"]].first.split(',').first || "/").strip
       end
 
       # :api: private

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -30,6 +30,32 @@ describe Rack::Test::Session do
       end
     end
 
+    it 'uses the first path when many paths are defiend' do
+      cookie_string = [
+      '/',
+      'csrf_id=ABC123',
+      'path=/, _github_ses=ABC123',
+      'path=/',
+      'expires=Wed, 01 Jan 2020 08:00:00 GMT',
+      'HttpOnly'
+      ].join('; ')
+      cookie = Rack::Test::Cookie.new(cookie_string)
+      cookie.path.should == '/'
+    end
+
+    it 'uses the first path when many paths are defiend' do
+      cookie_string = [
+      '/',
+      'csrf_id=ABC123',
+      'path=/',
+      'expires=Wed, 01 Jan 2020 08:00:00 GMT',
+      'HttpOnly'
+      ].join('; ')
+      cookie = Rack::Test::Cookie.new(cookie_string)
+      cookie.path.should == '/'
+    end
+
+
     it "escapes cookie values" do
       jar = Rack::Test::CookieJar.new
       jar["value"] = "foo;abc"


### PR DESCRIPTION
closes #16 "Rack::Test::CookieJar cannot handle multiple 'path' values in the Cookie."

However this is not a valid cookie string, I've found some web servers that ignore this and still deliver multiple keys. 

http://www.w3.org/Protocols/rfc2109/rfc2109

4.2.2  Set-Cookie Syntax

```
... If an attribute appears more than once in a cookie, the behaviour is undefined. ...
```
