### PR TITLE
Fix cookie default path

### DIFF
--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -63,7 +63,7 @@ module Rack
       end
 
       get "/cookies/default-path/" do
-        response.cookies.inspect
+        request.cookies.inspect
       end
 
       get "/cookies/delete" do

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -55,14 +55,14 @@ module Rack
         "Set"
       end
 
-      post "/cookies/default-path" do
+      post "/cookies/default-path/" do
         raise if params["value"].nil?
 
         response.set_cookie "simple", params["value"]
         "Set"
       end
 
-      get "/cookies/default-path" do
+      get "/cookies/default-path/" do
         response.cookies.inspect
       end
 

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -21,13 +21,11 @@ describe Rack::Test::Session do
     end
 
     it "cookie path defaults to the uri of the document that was requested" do
-      pending "See issue rack-test github issue #50" do
-        post "/cookies/default-path", "value" => "cookie"
-        get "/cookies/default-path"
-        check last_request.cookies.should == { "simple"=>"cookie" }
-        get "/cookies/show"
-        check last_request.cookies.should == { }
-      end
+      post "/cookies/default-path/", "value" => "cookie"
+      get "/cookies/default-path/"
+      check last_request.cookies.should == { "simple"=>"cookie" }
+      get "/cookies/show"
+      check last_request.cookies.should == { }
     end
 
     it "escapes cookie values" do


### PR DESCRIPTION
- Fix issue #50
  According to [rfc2109](http://www.w3.org/Protocols/rfc2109/rfc2109) 

```
   Path   Defaults to the path of the request URL that generated the
             Set-Cookie response, up to, but not including, the right-most /.
```

That is to say if your request url is `/cookie/default-path` the default path for the newly generated cookie is `/cookie`.  so when send request to `/cookie/default-path/`, the cookie's path will be `/cookie/default-path` and that's what the test case is for.
- fix a bug in fake_app
