### PR TITLE
Support HTTP HEAD request with query parameters.

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -205,7 +205,7 @@ module Rack
         # Stringifying and upcasing methods has be commit upstream
         env["REQUEST_METHOD"] ||= env[:method] ? env[:method].to_s.upcase : "GET"
 
-        if env["REQUEST_METHOD"] == "GET"
+        if ["GET", "HEAD"].include? env["REQUEST_METHOD"]
           # merge :params with the query string
           if params = env[:params]
             params = parse_nested_query(params) if params.is_a?(String)

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -432,67 +432,19 @@ describe Rack::Test::Session do
 
   describe "#get" do
     it_should_behave_like "any #verb methods"
+    it_should_behave_like "#verb methods with query params"
 
     def verb
       "get"
-    end
-
-    it "uses the provided params hash" do
-      get "/", :foo => "bar"
-      last_request.GET.should == { "foo" => "bar" }
-    end
-
-    it "sends params with parens in names" do
-      get "/", "foo(1i)" => "bar"
-      last_request.GET["foo(1i)"].should == "bar"
-    end
-
-    it "supports params with encoding sensitive names" do
-      get "/", "foo bar" => "baz"
-      last_request.GET["foo bar"].should == "baz"
-    end
-
-    it "supports params with nested encoding sensitive names" do
-      get "/", "boo" => {"foo bar" => "baz"}
-      last_request.GET.should == {"boo" => {"foo bar" => "baz"}}
-    end
-
-    it "accepts params in the path" do
-      get "/?foo=bar"
-      last_request.GET.should == { "foo" => "bar" }
     end
   end
 
   describe "#head" do
     it_should_behave_like "any #verb methods"
+    it_should_behave_like "#verb methods with query params"
 
     def verb
       "head"
-    end
-
-    it "uses the provided params hash" do
-      head "/", :foo => "bar"
-      last_request.GET.should == { "foo" => "bar" }
-    end
-
-    it "sends params with parens in names" do
-      head "/", "foo(1i)" => "bar"
-      last_request.GET["foo(1i)"].should == "bar"
-    end
-
-    it "supports params with encoding sensitive names" do
-      head "/", "foo bar" => "baz"
-      last_request.GET["foo bar"].should == "baz"
-    end
-
-    it "supports params with nested encoding sensitive names" do
-      head "/", "boo" => {"foo bar" => "baz"}
-      last_request.GET.should == {"boo" => {"foo bar" => "baz"}}
-    end
-
-    it "accepts params in the path" do
-      head "/?foo=bar"
-      last_request.GET.should == { "foo" => "bar" }
     end
   end
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -469,6 +469,31 @@ describe Rack::Test::Session do
     def verb
       "head"
     end
+
+    it "uses the provided params hash" do
+      head "/", :foo => "bar"
+      last_request.GET.should == { "foo" => "bar" }
+    end
+
+    it "sends params with parens in names" do
+      head "/", "foo(1i)" => "bar"
+      last_request.GET["foo(1i)"].should == "bar"
+    end
+
+    it "supports params with encoding sensitive names" do
+      head "/", "foo bar" => "baz"
+      last_request.GET["foo bar"].should == "baz"
+    end
+
+    it "supports params with nested encoding sensitive names" do
+      head "/", "boo" => {"foo bar" => "baz"}
+      last_request.GET.should == {"boo" => {"foo bar" => "baz"}}
+    end
+
+    it "accepts params in the path" do
+      head "/?foo=bar"
+      last_request.GET.should == { "foo" => "bar" }
+    end
   end
 
   describe "#post" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,3 +67,30 @@ shared_examples_for "any #verb methods" do
     end
   end
 end
+
+shared_examples_for "#verb methods with query params" do
+  it "uses the provided params hash" do
+    send(verb, "/", :foo => "bar")
+    last_request.GET.should == { "foo" => "bar" }
+  end
+
+  it "sends params with parens in names" do
+    send(verb, "/", "foo(1i)" => "bar")
+    last_request.GET["foo(1i)"].should == "bar"
+  end
+
+  it "supports params with encoding sensitive names" do
+    send(verb, "/", "foo bar" => "baz")
+    last_request.GET["foo bar"].should == "baz"
+  end
+
+  it "supports params with nested encoding sensitive names" do
+    send(verb, "/", "boo" => {"foo bar" => "baz"})
+    last_request.GET.should == {"boo" => {"foo bar" => "baz"}}
+  end
+
+  it "accepts params in the path" do
+    send(verb, "/?foo=bar")
+    last_request.GET.should == { "foo" => "bar" }
+  end
+end


### PR DESCRIPTION
Hi,

I suspect Rack::Test does not support HTTP HEAD request with query params.

I think the HEAD request should be able to handle query params as with the GET request.
But in the following code, HEAD is not treated same as GET.
https://github.com/futonaka/rack-test/blob/master/lib/rack/test.rb#L208

So I fixed this problem.
Would you check this pull request?

Thank you.

Futonaka
