### PR TITLE
Add custom_request, remove duplication

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -54,8 +54,7 @@ module Rack
       # Example:
       #   get "/"
       def get(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "GET", :params => params))
-        process_request(uri, env, &block)
+        custom_request("GET", uri, params, env, &block)
       end
 
       # Issue a POST request for the given URI. See #get
@@ -63,8 +62,7 @@ module Rack
       # Example:
       #   post "/signup", "name" => "Bryan"
       def post(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "POST", :params => params))
-        process_request(uri, env, &block)
+        custom_request("POST", uri, params, env, &block)
       end
 
       # Issue a PUT request for the given URI. See #get
@@ -72,8 +70,7 @@ module Rack
       # Example:
       #   put "/"
       def put(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "PUT", :params => params))
-        process_request(uri, env, &block)
+        custom_request("PUT", uri, params, env, &block)
       end
 
       # Issue a PATCH request for the given URI. See #get
@@ -81,8 +78,7 @@ module Rack
       # Example:
       #   patch "/"
       def patch(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "PATCH", :params => params))
-        process_request(uri, env, &block)
+        custom_request("PATCH", uri, params, env, &block)
       end
 
       # Issue a DELETE request for the given URI. See #get
@@ -90,8 +86,7 @@ module Rack
       # Example:
       #   delete "/"
       def delete(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "DELETE", :params => params))
-        process_request(uri, env, &block)
+        custom_request("DELETE", uri, params, env, &block)
       end
 
       # Issue an OPTIONS request for the given URI. See #get
@@ -99,8 +94,7 @@ module Rack
       # Example:
       #   options "/"
       def options(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "OPTIONS", :params => params))
-        process_request(uri, env, &block)
+        custom_request("OPTIONS", uri, params, env, &block)
       end
 
       # Issue a HEAD request for the given URI. See #get
@@ -108,8 +102,7 @@ module Rack
       # Example:
       #   head "/"
       def head(uri, params = {}, env = {}, &block)
-        env = env_for(uri, env.merge(:method => "HEAD", :params => params))
-        process_request(uri, env, &block)
+        custom_request("HEAD", uri, params, env, &block)
       end
 
       # Issue a request to the Rack app for the given URI and optional Rack
@@ -121,6 +114,15 @@ module Rack
       #   request "/"
       def request(uri, env = {}, &block)
         env = env_for(uri, env)
+        process_request(uri, env, &block)
+      end
+
+      # Issue a request using the given verb for the given URI. See #get
+      #
+      # Example:
+      #   custom_request "LINK", "/"
+      def custom_request(verb, uri, params = {}, env = {}, &block)
+        env = env_for(uri, env.merge(:method => verb.to_s.upcase, :params => params))
         process_request(uri, env, &block)
       end
 

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -65,6 +65,7 @@ module Rack
         :delete,
         :options,
         :head,
+        :custom_request,
         :follow_redirect!,
         :header,
         :env,

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -137,6 +137,10 @@ module Rack
       delete "/" do
         "Hello, DELETE: #{params.inspect}"
       end
+
+      link "/" do
+        "Hello, LINK: #{params.inspect}"
+      end
     end
 
   end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -430,6 +430,49 @@ describe Rack::Test::Session do
     end
   end
 
+  shared_examples_for "any #verb methods" do
+    it "requests the URL using VERB" do
+      public_send(verb, "/")
+
+      check last_request.env["REQUEST_METHOD"].should == verb.upcase
+      last_response.should be_ok
+    end
+
+    it "uses the provided env" do
+      public_send(verb, "/", {}, { "HTTP_USER_AGENT" => "Rack::Test" })
+      last_request.env["HTTP_USER_AGENT"].should == "Rack::Test"
+    end
+
+    it "yields the response to a given block" do
+      yielded = false
+
+      public_send(verb, "/") do |response|
+        response.should be_ok
+        yielded = true
+      end
+
+      yielded.should be_true
+    end
+
+    it "sets the HTTP_HOST header with port" do
+      public_send(verb, "http://example.org:8080/uri")
+      last_request.env["HTTP_HOST"].should == "example.org:8080"
+    end
+
+    it "sets the HTTP_HOST header without port" do
+      public_send(verb, "/uri")
+      last_request.env["HTTP_HOST"].should == "example.org"
+    end
+
+    context "for a XHR" do
+      it "sends XMLHttpRequest for the X-Requested-With header" do
+        public_send(verb, "/", {}, { :xhr => true })
+        last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
+        last_request.should be_xhr
+      end
+    end
+  end
+
   describe "#get" do
     it_should_behave_like "any #verb methods"
 
@@ -545,6 +588,49 @@ describe Rack::Test::Session do
 
     def verb
       "options"
+    end
+  end
+
+  describe "#custom_request" do
+    it "requests the URL using the given" do
+      custom_request("link", "/")
+
+      check last_request.env["REQUEST_METHOD"].should == "LINK"
+      last_response.should be_ok
+    end
+
+    it "uses the provided env" do
+      custom_request("link", "/", {}, { "HTTP_USER_AGENT" => "Rack::Test" })
+      last_request.env["HTTP_USER_AGENT"].should == "Rack::Test"
+    end
+
+    it "yields the response to a given block" do
+      yielded = false
+
+      custom_request("link", "/") do |response|
+        response.should be_ok
+        yielded = true
+      end
+
+      yielded.should be_true
+    end
+
+    it "sets the HTTP_HOST header with port" do
+      custom_request("link", "http://example.org:8080/uri")
+      last_request.env["HTTP_HOST"].should == "example.org:8080"
+    end
+
+    it "sets the HTTP_HOST header without port" do
+      custom_request("link", "/uri")
+      last_request.env["HTTP_HOST"].should == "example.org"
+    end
+
+    context "for a XHR" do
+      it "sends XMLHttpRequest for the X-Requested-With header" do
+        custom_request("link", "/", {}, { :xhr => true })
+        last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
+        last_request.should be_xhr
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,48 +22,4 @@ RSpec.configure do |config|
 
   def check(*args)
   end
-
-end
-
-shared_examples_for "any #verb methods" do
-  it "requests the URL using VERB" do
-    send(verb, "/")
-
-    check last_request.env["REQUEST_METHOD"].should == verb.upcase
-    last_response.should be_ok
-  end
-
-  it "uses the provided env" do
-    send(verb, "/", {}, { "HTTP_USER_AGENT" => "Rack::Test" })
-    last_request.env["HTTP_USER_AGENT"].should == "Rack::Test"
-  end
-
-  it "yields the response to a given block" do
-    yielded = false
-
-    send(verb, "/") do |response|
-      response.should be_ok
-      yielded = true
-    end
-
-    yielded.should be_true
-  end
-
-  it "sets the HTTP_HOST header with port" do
-    send(verb, "http://example.org:8080/uri")
-    last_request.env["HTTP_HOST"].should == "example.org:8080"
-  end
-
-  it "sets the HTTP_HOST header without port" do
-    send(verb, "/uri")
-    last_request.env["HTTP_HOST"].should == "example.org"
-  end
-
-  context "for a XHR" do
-    it "sends XMLHttpRequest for the X-Requested-With header" do
-      send(verb, "/", {}, { :xhr => true })
-      last_request.env["HTTP_X_REQUESTED_WITH"].should == "XMLHttpRequest"
-      last_request.should be_xhr
-    end
-  end
 end


### PR DESCRIPTION
I believe, it's not useful to support every HTTP verb defined everywhere with a custom method. But it should be possible to use those verbs, thus we should introduce a method to trigger requests with a
custom verb. Unfortunately, there is already a public request method, so I had to choose a different name.
