### PR TITLE
Remove 'uninitialized @digest_username' warning.

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -36,6 +36,7 @@ module Rack
       def initialize(mock_session)
         @headers = {}
         @env = {}
+        @digest_username = nil
 
         if mock_session.is_a?(MockSession)
           @rack_mock_session = mock_session


### PR DESCRIPTION
Related Tests: https://travis-ci.org/rails/rails/jobs/36882244

When a test returns a status of `401`, the following methods will be called:

``` ruby
# test.rb

def retry_with_digest_auth?(env)
  last_response.status == 401 &&
  digest_auth_configured? &&
  !env["rack-test.digest_auth_retry"]
end

def digest_auth_configured?
  @digest_username
end
```

However, if `digest_authorize` is not called by the tests, we will get this warning `warning: instance variable @digest_username not initialized` 

``` ruby
# Set the username and password for HTTP Digest authorization, to be
# included in subsequent requests in the HTTP_AUTHORIZATION header.
#
# Example:
#   digest_authorize "bryan", "secret"
def digest_authorize(username, password)
  @digest_username = username
  @digest_password = password
end
```
