### PR TITLE
Close tempfile after upload

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -31,6 +31,8 @@ module Rack
         @tempfile.binmode if binary
 
         FileUtils.copy_file(path, @tempfile.path)
+
+        @tempfile.close
       end
 
       def path

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -21,4 +21,13 @@ describe Rack::Test::UploadedFile do
     uploaded_file.should respond_to(:tempfile) # Allows calls to params[:file].tempfile
   end
 
+  it 'closes the tempfile in initialize' do
+    temp = Tempfile.new('test')
+    tempfile = mock('Tempfile')
+    tempfile.should_receive(:path).and_return(temp.path)
+    tempfile.should_receive(:close)
+    Tempfile.stub(:new).and_return(tempfile)
+
+    Rack::Test::UploadedFile.new(test_file_path)
+  end
 end


### PR DESCRIPTION
On a big project I've been working on we've had an issue where the test
suite handles a lot of file uploads. And as the total number of uploads
goes over 250 we would start getting core Ruby failures from reading
files. It couldn't even load normal .rb files anymore.

We fixed our test suite by making sure that tempfile closes the file it
was working on after it has been copied.
