### PR TITLE
Add license to gemspec

### DIFF
--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
     "spec/support/matchers/challenge.rb"
   ]
   s.homepage = "http://github.com/brynary/rack-test"
+  s.license = "MIT"
   s.require_paths = ["lib"]
   s.rubyforge_project = "rack-test"
   s.rubygems_version = "1.8.23"


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
