### PR TITLE
Use the same file extension for the Tempfile

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -26,7 +26,7 @@ module Rack
         @content_type = content_type
         @original_filename = ::File.basename(path)
 
-        @tempfile = Tempfile.new(@original_filename)
+        @tempfile = Tempfile.new([@original_filename, ::File.extname(path)])
         @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
         @tempfile.binmode if binary
 

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -21,4 +21,9 @@ describe Rack::Test::UploadedFile do
     uploaded_file.should respond_to(:tempfile) # Allows calls to params[:file].tempfile
   end
 
+  it "keeps the same file extension" do
+    uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+    File::extname(uploaded_file.tempfile).should == ".txt"
+  end
 end


### PR DESCRIPTION
@brynary 

I ran into a gotcha where we were trying to use `fixture_file_upload` to upload a file, but this made a Paperclip validation fail because the tempfile that was created by Rack::Test did not have the expected file extension.

Rack's `UploadedFile` implementation does preserve the file extension for tempfiles. See https://github.com/rack/rack/commit/2683d278913529400d13fd32b2a85e9eaa7f272c and https://github.com/rack/rack/issues/690 for additional context.

Before this fix, the test I added fails like this:

> Failures:
>   1) Rack::Test::UploadedFile keeps the same file extension
>      Failure/Error: File::extname(uploaded_file.tempfile).should == ".txt"
>        expected: ".txt"
>             got: ".txt20150128-29188-1pyvsrn" (using ==)
>      # ./spec/rack/test/uploaded_file_spec.rb:27:in `block (2 levels) in <top (required)>'
> Finished in 0.57648 seconds
> 190 examples, 1 failure, 2 pending

After this fix: all tests pass locally (except the 2 pending ones of course) — not sure what's up with CI.
