### PR TITLE
Added functionality (+spec) to convert empty arrays.

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -7,12 +7,16 @@ module Rack
       def build_nested_query(value, prefix = nil)
         case value
         when Array
-          value.map do |v|
-            unless unescape(prefix) =~ /\[\]$/
-              prefix = "#{prefix}[]"
-            end
-            build_nested_query(v, "#{prefix}")
-          end.join("&")
+          if value.empty?
+            "#{prefix}=#{escape(value)}"
+          else
+            value.map do |v|
+              unless unescape(prefix) =~ /\[\]$/
+                prefix = "#{prefix}[]"
+              end
+              build_nested_query(v, "#{prefix}")
+            end.join("&")
+          end
         when Hash
           value.map do |k, v|
             build_nested_query(v, prefix ? "#{prefix}[#{escape(k)}]" : escape(k))

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -48,6 +48,10 @@ describe Rack::Test::Utils do
     it "converts arrays of hashes" do
       build_nested_query(:a => [{ :b => 2}, { :c => 3}]).should == "a[][b]=2&a[][c]=3"
     end
+
+    it "converts empty arrays" do
+      build_nested_query(:a => []).should == "a=%5B%5D"
+    end
   end
 
   describe "build_multipart" do


### PR DESCRIPTION
As describes in issue #122 by @sheldon-b, empty arrays were not included in the converted params. This pull request fixes the issue and adds a spec to prevent future failure.

Please let me know if the pull request should be further improved.
