### PR TITLE
Fix creation of tempfiles in Rack::Test::UploadedFile

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -26,7 +26,7 @@ module Rack
         @content_type = content_type
         @original_filename = ::File.basename(path)
 
-        @tempfile = Tempfile.new(@original_filename)
+        @tempfile = Tempfile.new([@original_filename, ::File.extname(path)])
         @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
         @tempfile.binmode if binary
 

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -21,4 +21,9 @@ describe Rack::Test::UploadedFile do
     uploaded_file.should respond_to(:tempfile) # Allows calls to params[:file].tempfile
   end
 
+  it "creates Tempfiles with original file's extension" do
+    uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+    File.extname(uploaded_file.path).should eq(".txt")
+  end
 end


### PR DESCRIPTION
Tempfile's initializer is not very intuitive. If you want your tempfile
to have an extension you have to pass an array with two elements:
- basename
- extension (with a dot at the beginning)

This change makes it behave more like original Rack::Multipart::UploadedFile.
