### PR TITLE
Explicitly set license to MIT in .gemspec

### DIFF
--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Bryan Helmkamp"]
+  s.license = 'MIT'
   s.date = "2015-01-09"
   s.description = "Rack::Test is a small, simple testing API for Rack apps. It can be used on its\nown or as a reusable starting point for Web frameworks and testing libraries\nto build on. Most of its initial functionality is an extraction of Merb 1.0's\nrequest helpers feature."
   s.email = "bryan@brynary.com"


### PR DESCRIPTION
This will help out any tooling that reads the gemspec instead of scanning the contents.
