### PR TITLE
Do not set Content-Type for DELETE requests

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -205,7 +205,7 @@ module Rack
         # Stringifying and upcasing methods has be commit upstream
         env["REQUEST_METHOD"] ||= env[:method] ? env[:method].to_s.upcase : "GET"
 
-        if env["REQUEST_METHOD"] == "GET"
+        if ["GET", "DELETE"].include?(env["REQUEST_METHOD"])
           # merge :params with the query string
           if params = env[:params]
             params = parse_nested_query(params) if params.is_a?(String)

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -540,6 +540,12 @@ describe Rack::Test::Session do
   describe "#delete" do
     it_should_behave_like "any #verb methods"
 
+    it "does not set a content type" do
+      delete "/"
+
+      last_request.env['CONTENT_TYPE'].should be_nil
+    end
+
     def verb
       "delete"
     end


### PR DESCRIPTION
DELETE requests, like GET requests, should not have a Content-Type
header as there will not be a request body. However, rack-test attempts
to set a Content-Type of application/x-www-form-urlencoded which messes
with some web frameworks' test suites (including my own). Instead of
trying to set a Content-Type header and request body on DELETEs, treat
them more like GET requests.

Signed-off-by: David Celis me@davidcel.is
