### PR TITLE
Allow better testing of cookies

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -48,6 +48,10 @@ module Rack
         @options.has_key?("secure")
       end
 
+      def http_only?
+        @options.has_key?("HttpOnly")
+      end
+
       # :api: private
       def path
         @options["path"].strip || "/"
@@ -88,6 +92,15 @@ module Rack
         [name, path, domain.reverse] <=> [other.name, other.path, other.domain.reverse]
       end
 
+      def to_h
+        @options.merge(
+          "value" => @value,
+          "HttpOnly" => http_only?,
+          "secure" => secure?,
+        )
+      end
+      alias_method :to_hash, :to_h
+
     protected
 
       def default_uri
@@ -113,6 +126,10 @@ module Rack
 
       def []=(name, value)
         merge("#{name}=#{Rack::Utils.escape(value)}")
+      end
+
+      def get_cookie(name)
+        hash_for(nil).fetch(name, nil)
       end
 
       def delete(name)

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -215,5 +215,90 @@ describe Rack::Test::Session do
       request "/cookies/show", :cookie => "value=1"
       last_request.cookies.should == { "value" => "1" }
     end
+
+    describe Rack::Test::Cookie do
+      subject(:cookie) { Rack::Test::Cookie.new(cookie_string) }
+
+      let(:cookie_string) { raw_cookie_string }
+
+      let(:raw_cookie_string) {
+        [
+          "cookie_name=" + CGI.escape(value),
+          "domain=" + domain,
+          "path=" + path,
+          "expires=" + expires,
+        ].join("; ")
+      }
+
+      let(:http_only_raw_cookie_string) {
+        raw_cookie_string + "; HttpOnly"
+      }
+
+      let(:http_only_secure_raw_cookie_string) {
+        http_only_raw_cookie_string + "; secure"
+      }
+
+      let(:value) { "the cookie value" }
+      let(:domain) { "www.example.org" }
+      let(:path) { "/" }
+      let(:expires) { "Mon, 10 Aug 2015 14:40:57 0100" }
+
+      describe "#to_h" do
+        let(:cookie_string) { http_only_secure_raw_cookie_string }
+
+        it "returns the cookie value and all options" do
+          expect(cookie.to_h).to eq(
+            "value" => value,
+            "domain" => domain,
+            "path" => path,
+            "expires" => expires,
+            "HttpOnly" => true,
+            "secure" => true,
+          )
+        end
+      end
+
+      describe "#to_hash" do
+        it "is an alias for #to_h" do
+          expect(cookie.to_hash).to eq(cookie.to_h)
+        end
+      end
+
+      describe "#http_only?" do
+        context "for a non HTTP only cookie" do
+          it "returns false" do
+            expect(cookie.http_only?).to be(false)
+          end
+        end
+
+        context "for a HTTP only cookie" do
+          let(:cookie_string) { http_only_raw_cookie_string }
+
+          it "returns true" do
+            expect(cookie.http_only?).to be(true)
+          end
+        end
+      end
+    end
+
+    describe Rack::Test::CookieJar do
+      subject(:jar) { Rack::Test::CookieJar.new }
+
+      describe "#get_cookie" do
+        context "with a populated jar" do
+          let(:cookie_value) { "foo;abc" }
+          let(:cookie_name) { "a_cookie_name" }
+
+          before do
+            jar[cookie_name] = cookie_value
+          end
+
+          it "returns full cookie objects" do
+            cookie = jar.get_cookie(cookie_name)
+            expect(cookie).to be_a(Rack::Test::Cookie)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
It inconvenient to test cookies settings in depth because the current
behavior when retrieving a cookie is to return just the value. This can
be insufficient when you want to ensure that a cookie is HTTP only or
has a particular expiry time.
- Add CookieJar#get_cookie to return full cookie object
- Add Cookie#http_only? this value was previous somewhat hidden
- Add Cookie#to_h which returns all options and values in a Hash
