### PR TITLE
Adding a 'to_hash' method

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -46,6 +46,10 @@ module Rack
       def respond_to?(method_name, include_private = false) #:nodoc:
         @tempfile.respond_to?(method_name, include_private) || super
       end
+          
+      def to_hash
+        {content_type: self.content_type, original_filename: self.original_filename}
+      end
 
     end
 


### PR DESCRIPTION
The base `to_hash` method try to serialize all the attributes, and any json serialization fails on the encoding of the file.

``` sh
2.2.2 :001 > Rack::Test::UploadedFile.new("unnamed.jpg", "image/jpeg").to_json
 => {:content_type=>"image/jpeg", :original_filename=>"unnamed.jpg"}
2.2.2 :002 > {test: Rack::Test::UploadedFile.new("unnamed.jpg", "image/jpeg")}.to_json
Encoding::UndefinedConversionError: "\x89" from ASCII-8BIT to UTF-8
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `encode'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:34:in `to_json_with_active_support_encoder'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:57:in `to_json'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/json-1.8.3/lib/json/common.rb:223:in `generate'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/json-1.8.3/lib/json/common.rb:223:in `generate'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:101:in `stringify'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:35:in `encode'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:22:in `encode'
    from /Users/andral/.rvm/gems/ruby-2.2.2/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:37:in `to_json_with_active_support_encoder'
    from (irb):7
```
