### PR TITLE
Reuse request method and parameters on HTTP 307 redirect.

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -185,8 +185,11 @@ module Rack
         unless last_response.redirect?
           raise Error.new("Last response was not a redirect. Cannot follow_redirect!")
         end
-
-        get(last_response["Location"], {}, { "HTTP_REFERER" => last_request.url })
+        if last_response.status == 307
+          send(last_request.request_method.downcase.to_sym, last_response["Location"], last_request.params, { "HTTP_REFERER" => last_request.url })
+        else
+          get(last_response["Location"], {}, { "HTTP_REFERER" => last_request.url })
+        end
       end
 
     private

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -21,8 +21,19 @@ module Rack
         redirect "/redirected"
       end
 
-      get "/redirected" do
-        "You've been redirected"
+      post "/redirect" do
+        if params["status"]
+          redirect to("/redirected"), Integer(params["status"])
+        else
+          redirect "/redirected"
+        end
+      end
+
+      [:get, :put, :post, :delete].each do |meth|
+        send(meth, "/redirected") do
+          additional_info = (meth == :get) ? "" : " using #{meth} with #{params}"
+          "You've been redirected" + additional_info
+        end
       end
 
       get "/void" do

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -386,6 +386,16 @@ describe Rack::Test::Session do
         follow_redirect!
       }.to raise_error(Rack::Test::Error)
     end
+
+    context "for HTTP 307" do
+      it "keeps the original method" do
+        post "/redirect?status=307", {foo: "bar"}
+        follow_redirect!
+        last_response.body.should include "post"
+        last_response.body.should include "foo"
+        last_response.body.should include "bar"
+      end
+    end
   end
 
   describe "#last_request" do


### PR DESCRIPTION
This is a minimal patch with test that fixes #119 by keeping the original request method when forwarding with a 307.
