### PR TITLE
Rack::Test::Utils#build_multipart: Allow passing a third parameter to force multipart

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -26,13 +26,12 @@ module Rack
 
       module_function :build_nested_query
 
-      def build_multipart(params, first = true)
+      def build_multipart(params, first = true, multipart = false)
         if first
           unless params.is_a?(Hash)
             raise ArgumentError, "value must be a Hash"
           end
 
-          multipart = false
           query = lambda { |value|
             case value
             when Array


### PR DESCRIPTION
In some situations testing with multipart without actually adding a `UploadedFile` is necessary, e.g. to mimic a multipart form where no file was selected.
