### PR TITLE
Fix test suite for Rack 2.x compatiblity.

### DIFF
--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -61,7 +61,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["submit-name"].should == "Larry"
       check params["files"][:filename].should == "foo.txt"
       params["files"][:tempfile].read.should == "bar\n"
@@ -77,7 +77,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["submit-name"].should == "Larry"
 
       check params["files"][0][:filename].should == "foo.txt"
@@ -97,7 +97,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["people"][0]["submit-name"].should == "Larry"
       check params["people"][0]["files"][:filename].should == "foo.txt"
       params["people"][0]["files"][:tempfile].read.should == "bar\n"
@@ -114,7 +114,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["files"][:filename].should == "foo.txt"
       params["files"][:tempfile].read.should == "bar\n"
       check params["foo"].should == [{"id" => "1", "name" => "Dave"}, {"id" => "2", "name" => "Steve"}]
@@ -132,7 +132,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["files"][:filename].should == "foo.txt"
       params["files"][:tempfile].read.should == "bar\n"
       check params["foo"].should == {"bar" => [{"id" => "1", "name" => "Dave"},
@@ -150,7 +150,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["files"][0][:filename].should == "foo.txt"
       params["files"][0][:tempfile].read.should == "bar\n"
       check params["foo"][0].should == "1"
@@ -168,7 +168,7 @@ describe Rack::Test::Utils do
         :input => StringIO.new(data)
       }
       env = Rack::MockRequest.env_for("/", options)
-      params = Rack::Utils::Multipart.parse_multipart(env)
+      params = Rack::Multipart.parse_multipart(env)
       check params["foo"][0]["id"].should == "1"
       check params["foo"][0]["data"][:filename].should == "foo.txt"
       params["foo"][0]["data"][:tempfile].read.should == "bar\n"


### PR DESCRIPTION
The test suite does not pass when testing against Rack 2.x. It fails with following error:

```
  1) Rack::Test::Utils build_multipart builds multipart bodies
     Failure/Error: params = Rack::Utils::Multipart.parse_multipart(env)
     NameError:
       uninitialized constant Rack::Utils::Multipart
     # ./spec/rack/test/utils_spec.rb:64:in `block (3 levels) in <top (required)>'
```

This is caused by this change https://github.com/rack/rack/commit/b2d73960e9ea6b8b15321ef190f13a290d1aedf0#diff-7c1a24d5b2fe58a6f925c7cacc6c55e7L573 in Rack.
