### PR TITLE
Add the ability to create Test::UploadedFile instances without the file system

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -40,11 +40,11 @@ module Rack
       alias local_path path
 
       def method_missing(method_name, *args, &block) #:nodoc:
-        @tempfile.__send__(method_name, *args, &block)
+        tempfile.public_send(method_name, *args, &block)
       end
 
-      def respond_to?(method_name, include_private = false) #:nodoc:
-        @tempfile.respond_to?(method_name, include_private) || super
+      def respond_to_missing?(method_name, include_private = false) #:nodoc:
+        tempfile.respond_to?(method_name, include_private) || super
       end
 
       def self.finalize(file)

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -128,17 +128,15 @@ EOF
       module_function :build_primitive_part
 
       def build_file_part(parameter_name, uploaded_file)
-        ::File.open(uploaded_file.path, 'rb') do |physical_file|
-          physical_file.set_encoding(Encoding::BINARY) if physical_file.respond_to?(:set_encoding)
-          <<-EOF
+        uploaded_file.set_encoding(Encoding::BINARY) if uploaded_file.respond_to?(:set_encoding)
+        <<-EOF
 --#{MULTIPART_BOUNDARY}\r
 Content-Disposition: form-data; name="#{parameter_name}"; filename="#{escape(uploaded_file.original_filename)}"\r
 Content-Type: #{uploaded_file.content_type}\r
-Content-Length: #{::File.stat(uploaded_file.path).size}\r
+Content-Length: #{uploaded_file.size}\r
 \r
-#{physical_file.read}\r
+#{uploaded_file.read}\r
 EOF
-        end
       end
       module_function :build_file_part
     end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -43,4 +43,27 @@ describe Rack::Test::UploadedFile do
       end
     end
   end
+
+  describe '#initialize' do
+    subject { -> { uploaded_file } }
+    let(:uploaded_file) { described_class.new(io, original_filename: original_filename) }
+
+    context 'with an IO object' do
+      let(:io) { StringIO.new('I am content') }
+
+      context 'with an original filename' do
+        let(:original_filename) { 'content.txt' }
+
+        it 'sets the specified filename' do
+          subject.call
+          uploaded_file.original_filename.should == original_filename
+        end
+      end
+
+      context 'without an original filename' do
+        let(:original_filename) { nil }
+        it { should raise_error(ArgumentError) }
+      end
+    end
+  end
 end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -14,17 +14,9 @@ describe Rack::Test::UploadedFile do
   it 'responds to things that Tempfile responds to' do
     uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
-    expect(uploaded_file).to respond_to(:close)
-    expect(uploaded_file).to respond_to(:close!)
-    expect(uploaded_file).to respond_to(:delete)
-    expect(uploaded_file).to respond_to(:length)
-    expect(uploaded_file).to respond_to(:open)
-    expect(uploaded_file).to respond_to(:path)
-    expect(uploaded_file).to respond_to(:size)
-    expect(uploaded_file).to respond_to(:unlink)
-    expect(uploaded_file).to respond_to(:read)
-    expect(uploaded_file).to respond_to(:original_filename)
-    expect(uploaded_file).to respond_to(:tempfile) # Allows calls to params[:file].tempfile
+    Tempfile.public_instance_methods(false).each do |method|
+      expect(uploaded_file).to respond_to(method)
+    end
   end
 
   it "creates Tempfiles with original file's extension" do


### PR DESCRIPTION
Uploaded files behave as IO streams, so it should be reasonable to instantiate a fake one from an IO stream.  These changes don't change the existing interface to the `#initialize` method, but add the ability to do something like this:

``` ruby
io = StringIO.new('Some content')
upload = Rack::Test::UploadedFile.new(io, original_filename: 'wibble.txt')
...
```

A lot of tests for content uploads don't need a lot of complex content; this should allow for test suites without a bunch of tiny test files cluttering the project or spec directories.
