### PR TITLE
Fix warning on usage

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -281,7 +281,7 @@ module Rack
       end
 
       def digest_auth_configured?
-        @digest_username
+        defined?(@digest_username)
       end
 
       def default_env


### PR DESCRIPTION
I see this warning on every usage:

```
~/.gem/jruby/2.3.1/gems/rack-test-0.6.3/lib/rack/test.rb:285: warning: instance variable @digest_username not initialized
```