### PR TITLE
allows symbol access to cookies

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -120,7 +120,7 @@ module Rack
       def [](name)
         cookies = hash_for(nil)
         # TODO: Should be case insensitive
-        cookies[name] && cookies[name].value
+        cookies[name.to_s] && cookies[name.to_s].value
       end
 
       def []=(name, value)

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -43,6 +43,12 @@ describe Rack::Test::Session do
       expect(jar["abcd"]).to eq(nil)
     end
 
+    it "allow symbol access" do
+      jar = Rack::Test::CookieJar.new
+      jar["value"] = "foo;abc"
+      jar[:value].should == "foo;abc"
+    end
+
     it "doesn't send cookies with the wrong domain" do
       get "http://www.example.com/cookies/set", "value" => "1"
       get "http://www.other.example/cookies/show"


### PR DESCRIPTION
I think it's better if cookies method allows symbol access.

Symbol is available for `cookies method` in Ruby on Rails, but  not available for testing.
Because rack-test is used in Ruby on Rails, but not allow symbol access to cookies.
This problem is also written in `RUBY ON RAILS TUTORIAL (RAILS 5)`.
(@Chapter 9.3)

> There’s one more subtlety, which is that for some reason inside tests the cookies method doesn’t > work with symbols as keys, so that
>
> ```cookies[:remember_token]```
> is always nil. Luckily, cookies does work with string keys, so that
>
> ```cookies['remember_token']```
> has the value we need.

Ruby on Rails cookies method
https://github.com/rails/rails/blob/15a972e080d7712aa2eb04f21472398457d1439c/actionpack/lib/action_dispatch/middleware/cookies.rb#L315%23L317
```
# Returns the value of the cookie by +name+, or +nil+ if no such cookie exists.
def [](name)
  @cookies[name.to_s]
end
```

I hope that this PR will be merged.
Regards.