### PR TITLE
Don't append an ampersand when params are empty

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -210,7 +210,7 @@ module Rack
           if params = env[:params]
             params = parse_nested_query(params) if params.is_a?(String)
 
-            uri.query = [uri.query, build_nested_query(params)].compact.join("&")
+            uri.query = [uri.query, build_nested_query(params)].compact.reject { |v| v == '' }.join("&")
           end
         elsif !env.has_key?(:input)
           env["CONTENT_TYPE"] ||= "application/x-www-form-urlencoded"

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -127,6 +127,11 @@ describe Rack::Test::Session do
       last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5+%20"
     end
 
+    it "does not rewrite a GET query string when :params is empty" do
+      request "/foo?a=1&b=2&c=3&e=4&d=5", :params => {}
+      last_request.query_string.should == "a=1&b=2&c=3&e=4&d=5"
+    end
+
     it "does not overwrite multiple query string keys" do
       request "/foo?a=1&a=2", :params => { :bar => 1 }
       last_request.query_string.should == "a=1&a=2&bar=1"


### PR DESCRIPTION
[This commit](https://github.com/brynary/rack-test/commit/4a4b2c1bde9ce00929df2d5458915e342b9c1ea1) caused an unneeded ampersand to be appended to the query string. I added a test and fixed the issue.