### PR TITLE
Add .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 pkg
 doc
 coverage
+Gemfile.lock
 VERSION
 *.rbc
 .bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+before_install:
+  - which bundle || gem install bundler
+rvm:
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+  - jruby-9.1.8.0
+  - jruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+  fast_finish: true


### PR DESCRIPTION
The PR to add Travis test environment.

I added officially supported Rubies.
I added ruby-head as allow_failures.

I think this is a good practice.
Because we can see the result for the next version Ruby as faster.

We can see it in `rails`, `rspec` and `cucumber` and etc too.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

I decided `rack-test` supported platforms referring `rack`.
https://github.com/rack/rack/blob/master/.travis.yml

Below code in `.travis.yml` is because of `jruby-head` environment.
`jruby-head` does not install Bundler as default.

```
  - which bundle || gem install bundler
```

Below code that is used in `rack/rack` does not work. I do not know why.
https://travis-ci.org/rack-test/rack-test/jobs/224783394

```
  - gem list -i bundler || gem install bundler
```

`jruby-9.1.8.0` is latest stable version of JRuby.
http://jruby.org/download

About Rubinious, I tried to set below values, but failed to detect those from Travis.
`rbx-2`, `rbx-3`, `rbx-3.74`
So, I dropped those right now.
`rbx` is really not stable on Travis.
 



