### PR TITLE
Updates README.rdoc with code example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,25 +17,31 @@ request helpers feature.
 * Small footprint. Approximately 200 LOC
 
 == Examples
-
+  require "test/unit"
   require "rack/test"
 
   class HomepageTest < Test::Unit::TestCase
     include Rack::Test::Methods
 
     def app
-      MyApp.new
+      app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['All responses are OK']] }
+      builder = Rack::Builder.new
+      builder.run app
     end
 
-    def test_redirect_logged_in_users_to_dashboard
-      authorize "bryan", "secret"
+    def test_response_is_ok
       get "/"
-      follow_redirect!
 
-      assert_equal "http://example.org/redirected", last_request.url
       assert last_response.ok?
+      assert_equal last_response.body, "All responses are OK"
     end
 
+    def test_response_is_ok_for_other_paths
+      get "/other_paths"
+
+      assert last_response.ok?
+      assert_equal last_response.body, "All responses are OK"
+    end
   end
 
 
@@ -69,13 +75,10 @@ Or via Bundler:
 
 == Authors
 
-- Maintained by {Bryan Helmkamp}[mailto:bryan@brynary.com]
-- Contributions from Simon Rozet, Pat Nakajima and others
-- Much of the original code was extracted from Merb 1.0's request helper
+- Contributions from Bryan Helmkamp, Simon Rozet, Pat Nakajima and others
 
 == License
 
-Copyright (c) 2008-2009 Bryan Helmkamp, Engine Yard Inc.
 See MIT-LICENSE.txt in this directory.
 
 == Releasing


### PR DESCRIPTION
This PR implements PRs #65, #74, #76.
Some of the PRs contain similar content and other are no longer
based on the current readme. THis is an attempt to clean up the
readme state. 

In addition some suggestions for further updates
are part of the PR to raise the discussion about:
List of maintainers and the format (email or github username) and
the copyright text we want to have (or not have).
@perlun @junaruga please let me know your point of view