### PR TITLE
FIX: Ensure Rack::Test::UploadedFile closes its tempfile file descriptor on GC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ VERSION
 *.rbc
 *.swp
 /.bundle
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ VERSION
 *.rbc
 *.swp
 /.bundle
-.idea/
+/.idea

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -30,9 +30,9 @@ module Rack
         @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
         @tempfile.binmode if binary
 
-        FileUtils.copy_file(path, @tempfile.path)
-
         ObjectSpace.define_finalizer( self, self.class.finalize(@tempfile) )
+
+        FileUtils.copy_file(path, @tempfile.path)
       end
 
       def path

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -55,6 +55,7 @@ module Rack
 
       def self.actually_finalize(file)
         file.close
+        file.unlink
       end
 
     end

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -31,6 +31,8 @@ module Rack
         @tempfile.binmode if binary
 
         FileUtils.copy_file(path, @tempfile.path)
+
+        ObjectSpace.define_finalizer( self, self.class.finalize(@tempfile) )
       end
 
       def path
@@ -45,6 +47,14 @@ module Rack
 
       def respond_to?(method_name, include_private = false) #:nodoc:
         @tempfile.respond_to?(method_name, include_private) || super
+      end
+
+      def self.finalize(file)
+        proc { actually_finalize file }
+      end
+
+      def self.actually_finalize(file)
+        file.close
       end
 
     end

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -30,7 +30,7 @@ module Rack
         @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
         @tempfile.binmode if binary
 
-        ObjectSpace.define_finalizer( self, self.class.finalize(@tempfile) )
+        ObjectSpace.define_finalizer(self, self.class.finalize(@tempfile))
 
         FileUtils.copy_file(path, @tempfile.path)
       end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -33,8 +33,8 @@ describe Rack::Test::UploadedFile do
     expect(File.extname(uploaded_file.path)).to eq(".txt")
   end
 
-  context 'it should call its destructor' do
-    it 'calls the destructor' do
+  context "it should call its destructor" do
+    it "calls the destructor" do
       expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)
 
       if RUBY_PLATFORM == 'java' && RUBY_VERSION == '2.3.1'

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -26,4 +26,15 @@ describe Rack::Test::UploadedFile do
 
     expect(File.extname(uploaded_file.path)).to eq(".txt")
   end
+
+  context 'it should call its destructor' do
+    it 'calls the destructor' do
+      uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+      expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)
+
+      uploaded_file = nil
+      GC.start
+    end
+  end
 end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -33,8 +33,8 @@ describe Rack::Test::UploadedFile do
     expect(File.extname(uploaded_file.path)).to eq(".txt")
   end
 
-  context 'it should call its destructor' do
-    it 'calls the destructor' do
+  context "it should call its destructor" do
+    it "calls the destructor" do
       uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
       expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -37,7 +37,7 @@ describe Rack::Test::UploadedFile do
     it "calls the destructor" do
       expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)
 
-      if RUBY_PLATFORM == 'java' && RUBY_VERSION == '2.3.1'
+      if RUBY_PLATFORM == 'java'
         require 'java'
         java_import 'java.lang.System'
 

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -33,14 +33,28 @@ describe Rack::Test::UploadedFile do
     expect(File.extname(uploaded_file.path)).to eq(".txt")
   end
 
-  context "it should call its destructor" do
-    it "calls the destructor" do
-      uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
-
+  context 'it should call its destructor' do
+    it 'calls the destructor' do
       expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)
 
-      uploaded_file = nil
-      GC.start
+      if RUBY_PLATFORM == 'java' && RUBY_VERSION == '2.3.1'
+        require 'java'
+        java_import 'java.lang.System'
+
+        20.times do |i|
+          uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+          uploaded_file = nil
+
+          System.gc()
+        end
+      else
+        uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+        uploaded_file = nil
+
+        GC.start
+      end
     end
   end
 end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -5,6 +5,12 @@ describe Rack::Test::UploadedFile do
     File.dirname(__FILE__) + "/../../fixtures/foo.txt"
   end
 
+  it "returns an instance of `Rack::Test::UploadedFile`" do
+    uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+    expect(uploaded_file).to be_a(Rack::Test::UploadedFile)
+  end
+
   it "responds to things that Tempfile responds to" do
     uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 


### PR DESCRIPTION
Hi all - I noticed the file descriptor of the tempfile is left 'hanging' and have ensured it is closed on GC.

Cheers!