### PR TITLE
Stopping generating gemspec file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,15 @@ before_install:
   - which bundle || gem install bundler
 script:
   - bundle list
+  # Unit test
   - bundle exec rake
+  # Release test
+  - bundle exec thor :build
+  - ls -l pkg/rack-test-*.gem
+  - gem install pkg/rack-test-*.gem
+  - gem list rack-test
+  - ruby -e 'require "rack/test"'
+  - gem specification pkg/rack-test-*.gem --ruby
 rvm:
   - 2.2.7
   - 2.3.4

--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Development dependency
-gem 'rake'
-gem 'rspec'
-# To use rack 2
-gem 'sinatra', '~> 2.0'
-# Keep version < 1 to supress deprecated warning temporary.
-gem 'codeclimate-test-reporter', '< 1', :require => false
-
-# For Thorfile. Run "bundle exec thor help" to see the help.
-gem 'thor'
-gem 'git'
+# Runtime dependency
+gem 'rack', '~> 2.0'

--- a/Gemfile.rack-1.x
+++ b/Gemfile.rack-1.x
@@ -4,10 +4,3 @@ gemspec
 
 # Runtime dependency
 gem 'rack', '< 2'
-
-# Development dependency
-gem 'rake'
-gem 'rspec'
-gem 'sinatra'
-# Keep version < 1 to supress deprecated warning temporary.
-gem 'codeclimate-test-reporter', '< 1', :require => false

--- a/README.md
+++ b/README.md
@@ -94,3 +94,9 @@ Contributions are welcome. Please make sure to:
 * Write tests for the new or changed behaviour
 * Provide an explanation/motivation in your commit message / PR message
 * Ensure History.txt is updated
+
+## Releasing
+
+* Ensure History.txt is up-to-date
+* Bump VERSION in lib/rack/test/version.rb
+* bundle exec thor :release

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -6,11 +6,10 @@ require "rack/test/mock_digest_request"
 require "rack/test/utils"
 require "rack/test/methods"
 require "rack/test/uploaded_file"
+require "rack/test/version"
 
 module Rack
   module Test
-    VERSION = "0.6.3"
-
     DEFAULT_HOST = "example.org"
     MULTIPART_BOUNDARY = "----------XnJLe9ZIbbGUYtzPQJ16u1"
 

--- a/lib/rack/test/version.rb
+++ b/lib/rack/test/version.rb
@@ -1,0 +1,5 @@
+module Rack
+  module Test
+    VERSION = "0.6.3"
+  end
+end

--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -1,84 +1,32 @@
 # -*- encoding: utf-8 -*-
-# stub: rack-test 0.6.3 ruby lib
+
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'rack/test/version'
 
 Gem::Specification.new do |s|
-  s.name = "rack-test"
-  s.version = "0.6.3"
-
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Bryan Helmkamp"]
-  s.date = "2017-05-08"
-  s.description = "Rack::Test is a small, simple testing API for Rack apps. It can be used on its\nown or as a reusable starting point for Web frameworks and testing libraries\nto build on. Most of its initial functionality is an extraction of Merb 1.0's\nrequest helpers feature."
-  s.email = "bryan@brynary.com"
-  s.extra_rdoc_files = [
-    "README.rdoc",
-    "MIT-LICENSE.txt"
-  ]
-  s.files = [
-    ".document",
-    ".gitignore",
-    ".travis.yml",
-    "Gemfile",
-    "Gemfile.rack-1.x",
-    "History.txt",
-    "MIT-LICENSE.txt",
-    "README.rdoc",
-    "Rakefile",
-    "Thorfile",
-    "lib/rack/mock_session.rb",
-    "lib/rack/test.rb",
-    "lib/rack/test/cookie_jar.rb",
-    "lib/rack/test/methods.rb",
-    "lib/rack/test/mock_digest_request.rb",
-    "lib/rack/test/uploaded_file.rb",
-    "lib/rack/test/utils.rb",
-    "rack-test.gemspec",
-    "spec/fixtures/bar.txt",
-    "spec/fixtures/config.ru",
-    "spec/fixtures/fake_app.rb",
-    "spec/fixtures/foo.txt",
-    "spec/rack/test/cookie_jar_spec.rb",
-    "spec/rack/test/cookie_object_spec.rb",
-    "spec/rack/test/cookie_spec.rb",
-    "spec/rack/test/digest_auth_spec.rb",
-    "spec/rack/test/multipart_spec.rb",
-    "spec/rack/test/uploaded_file_spec.rb",
-    "spec/rack/test/utils_spec.rb",
-    "spec/rack/test_spec.rb",
-    "spec/spec_helper.rb",
-    "spec/support/matchers/body.rb",
-    "spec/support/matchers/challenge.rb"
-  ]
-  s.homepage = "http://github.com/rack-test/rack-test"
-  s.licenses = ["MIT"]
-  s.rubyforge_project = "rack-test"
-  s.rubygems_version = "2.4.5.2"
-  s.summary = "Simple testing API built on Rack"
-  s.test_files = [
-    "spec/fixtures/fake_app.rb",
-    "spec/rack/test/cookie_jar_spec.rb",
-    "spec/rack/test/cookie_object_spec.rb",
-    "spec/rack/test/cookie_spec.rb",
-    "spec/rack/test/digest_auth_spec.rb",
-    "spec/rack/test/multipart_spec.rb",
-    "spec/rack/test/uploaded_file_spec.rb",
-    "spec/rack/test/utils_spec.rb",
-    "spec/rack/test_spec.rb",
-    "spec/spec_helper.rb",
-    "spec/support/matchers/body.rb",
-    "spec/support/matchers/challenge.rb"
-  ]
-
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rack>, [">= 1.0"])
-    else
-      s.add_dependency(%q<rack>, [">= 1.0"])
-    end
-  else
-    s.add_dependency(%q<rack>, [">= 1.0"])
-  end
+  s.name = 'rack-test'
+  s.version = Rack::Test::VERSION
+  s.platform = Gem::Platform::RUBY
+  s.author = 'Bryan Helmkamp'
+  s.email = 'bryan@brynary.com'
+  s.license = 'MIT'
+  s.homepage = 'http://github.com/rack-test/rack-test'
+  s.summary = 'Simple testing API built on Rack'
+  s.description = <<-EOS.strip
+Rack::Test is a small, simple testing API for Rack apps. It can be used on its
+own or as a reusable starting point for Web frameworks and testing libraries
+to build on. Most of its initial functionality is an extraction of Merb 1.0's
+request helpers feature.
+  EOS
+  s.require_paths = ['lib']
+  s.files = `git ls-files -- lib/*`.split("\n") +
+            %w[History.md MIT-LICENSE.txt README.md]
+  s.add_dependency 'rack', '>= 1.0', '< 3'
+  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rspec', '~> 3.6'
+  s.add_development_dependency 'sinatra', '>= 1.0', '< 3'
+  # Keep version < 1 to supress deprecated warning temporary.
+  s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
+  # For Thorfile. Run "bundle exec thor help" to see the help.
+  s.add_development_dependency 'thor', '~>  0.19'
 end


### PR DESCRIPTION
This fixes https://github.com/rack-test/rack-test/issues/169

## Summary

* I stopped generating gemspec file from `Thorfile`.
  That confusing us including contributors.
  There is a way to manage gemspec file statically.
  Ref: 
  * Listen: https://github.com/guard/listen/blob/master/listen.gemspec
  * RSpec-Core: https://github.com/rspec/rspec-core/blob/master/rspec-core.gemspec
  * Rack: https://github.com/rack/rack/blob/master/rack.gemspec

* I created new file lib/rack/test/version.rb newly to manage version string.
  Because when I tried to load `require "rack/test"` in the gemspec file , then `bundle install`, that causes install error. When I searched internet (https://github.com/thoughtbot/administrate/issues/717),  it is related that `rack/test` is recursively loaded. So, I referred above Listen's way.

* I added Release way to README again because that is useful for people who do release.
  You can check modified README here: https://github.com/junaruga/rack-test/blob/feature/stop-generating-gemspec/README.md

* I added release test to `.travis.yml. This is because I wanted to test gemspec file and release script.

## Detail

* rack-test.gemspec
  * Replacing from double quote `"` to single quote `'` is to pass rubocop latest version 0.49.0 test. There is one violation error for the rubocop test for here document. But can not avoid it.
  * s.files: I only included files under `lib` and some document files.
  This way removing test files is maybe new popular. For example you can see it on `rails/rails`, `rspec/rspec-*`, the merit is we can reduce the file size of gem.
  * s.required_rubygems_version: Removed. Removing it looks no harmful, referring other packages' gemspec files. The item looks auto-generated by RubyGems. See the result of `gem specification` on Travis CI.
  * s.extra_rdoc_files: Removed. It looks no harmful.
  * s.rubyforge_project: Removed. Outdated? We don't use Rubyforge.
  * s.rubygems_version: Removed. We don't want to maintain the version.
    I did not see this item at `rais/rails`, `rspec-core`.
    http://guides.rubygems.org/specification-reference/#rubygems_version
    > Do not set this, it is set automatically when the gem is packaged.
  * s.test_files: Removed. Seeing http://guides.rubygems.org/specification-reference, it look outdated tag. Also I did not see it on rails.
  * s.add_dependency or s.add_runtime_dependency ?
    Both are same meaning items. But maybe add_runtime_dependency is newer than add_dependency. Seeing `rails/rails` add_dependency is used. So, I used it for the compativility of older Rubies.

I also removed/updated those items referring http://guides.rubygems.org/specification-reference/ , `rails/rails` and `rspec/rspec-core`. So, if you have questions, please let me know.

* .travis.yml
  * The release test is too much? :)

* Thorfile
  * My concern is `$ bundle exec thor :install` itself is not useful. Because `gem install --local pkg/rack-test-*.gem` is run in the Bundler world.

```
$ bundle show rack-test
/home/jaruga/git/rack-test

$ bundle exec thor :build
gem build rack-test.gemspec
  Successfully built RubyGem
  Name: rack-test
  Version: 0.6.3
  File: rack-test-0.6.3.gem

$ bundle exec thor :install

$ bundle show rack-test
/home/jaruga/git/rack-test
```

## How to test

```
$ bundle exec thor :build

$ gem install --user-install pkg/rack-test-0.6.3.gem

$ gem list | grep rack-test
rack-test (0.6.3)

irb(main):003:0> require 'rack/test'
=> true

$ gem specification pkg/rack-test-0.6.3.gem --ruby

$ cd pkg/

$ gem unpack rack-test-0.6.3.gem 
Unpacked gem: '/home/jaruga/git/rack-test/pkg/rack-test-0.6.3'

$ ls rack-test-0.6.3
History.md  lib/  MIT-LICENSE.txt  README.md
```
