### PR TITLE
Fix errors at rake docs and whitespace.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,11 +23,11 @@ task :default => :spec
 desc "Generate RDoc"
 task :docs do
   FileUtils.rm_rf("doc")
-  require "rack/test"
-  system "hanna --title 'Rack::Test #{Rack::Test::VERSION} API Documentation'"
+  require "rack/test/version"
+  sh "rdoc --title 'Rack::Test #{Rack::Test::VERSION} API Documentation'"
 end
 
 desc 'Removes trailing whitespace'
 task :whitespace do
-  sh %{find . -name '*.rb' -exec sed -i '' 's/ *$//g' {} \\;}
+  sh %{find . -name '*.rb' -exec sed -i 's/ *$//g' {} \\;}
 end

--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -25,6 +25,7 @@ request helpers feature.
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'sinatra', '>= 1.0', '< 3'
+  s.add_development_dependency 'rdoc', '~> 5.1'
   # Keep version < 1 to supress deprecated warning temporary.
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
   # For Thorfile. Run "bundle exec thor help" to see the help.


### PR DESCRIPTION
This fixes https://github.com/rack-test/rack-test/issues/182

## Summary

* Fix rake whitespace.
  I changed the `sed` command format to run on GNU sed. Another version `sed` has been used before?
* Change `hanna` to `rdoc` to generate RDoc document.
  Because `hanna` latest version 0.1.12 is using very old rake as runtime dependency.
  That causes install error.
  `rdoc` does not have any runtime dependency. It looks better.

Ref:

* https://rubygems.org/gems/hanna
  runtime dependencies
  rake ~> 0.8.2
* https://rubygems.org/gems/rake
  rake is 12.0.0

## Use cases

### whitespace

```
$ vi lib/rack/test.rb

$ git status
On branch hotfix/fix-rake-docs-and-whitespace
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   lib/rack/test.rb
...

$ git diff
diff --git a/lib/rack/test.rb b/lib/rack/test.rb
index b7288c6..8aa3f85 100644
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -6,7 +6,7 @@ require "rack/test/mock_digest_request"
 require "rack/test/utils"
 require "rack/test/methods"
 require "rack/test/uploaded_file"
-require "rack/test/version"
+require "rack/test/version"   <= tailing space
 
 module Rack
   module Test

$ bundle exec rake whitespace
find . -name '*.rb' -exec sed -i 's/ *$//g' {} \;

$ git status
<= no difference
```

### docs

```
$ bundle exec rake docs
...
rdoc --title 'Rack::Test 0.6.3 API Documentation'
Parsing sources...
...
```

Then see `doc/index.html`.
