### PR TITLE
Change codeclimate URL correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rack::Test
 [<img src="https://travis-ci.org/rack-test/rack-test.svg?branch=master" />](https://travis-ci.org/rack-test/rack-test)
-[<img src="https://codeclimate.com/github/brynary/rack-test.png" />](https://codeclimate.com/github/brynary/rack-test)
-[<img src="https://codeclimate.com/github/brynary/rack-test/coverage.png" />](https://codeclimate.com/github/brynary/rack-test)
+[<img src="https://codeclimate.com/github/rack-test/rack-test.png" />](https://codeclimate.com/github/rack-test/rack-test)
+[<img src="https://codeclimate.com/github/rack-test/rack-test/coverage.png" />](https://codeclimate.com/github/rack-test/rack-test)
 
 Code: https://github.com/rack-test/rack-test
 


### PR DESCRIPTION
This PR fixes https://github.com/rack-test/rack-test/issues/177

Let's correct our team mate Bryan's service :)

I changed the codeclimate correctly.

However look at this page, that I modified.
The badge images are broken.
https://github.com/junaruga/rack-test/tree/hotfix/change-codeclimate-correctly

The reason is out page does not start codeclime service.
I could not start by myself.

Maybe @perlun can start? Can you check to start climate?
New page (Not found): https://codeclimate.com/github/rack-test/rack-test
Current page: https://codeclimate.com/github/brynary/rack-test

Thanks.
