### PR TITLE
Add Rubocop task to Rakefile.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+# Ref: default config
+# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+AllCops:
+  Include:
+    - '{lib,spec}/**/*.rb'
+    - 'Gemfile'
+    - 'Gemfile.rack-1.x'
+    - 'rack-test.gemspec'
+    - 'Rakefile'
+    - 'Thorfile'
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  ExtraDetails: true

--- a/Rakefile
+++ b/Rakefile
@@ -4,12 +4,15 @@ require "rubygems"
 require 'rspec/core'
 require "rspec/core/rake_task"
 
+task default: :spec
+
 RSpec::Core::RakeTask.new do |t|
   t.pattern = "spec/**/*_spec.rb"
   t.ruby_opts = "-w"
 end
 
-task :default => :spec
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
 
 # desc "Run all specs in spec directory with RCov"
 # RSpec::Core::RakeTask.new(:rcov) do |t|

--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -26,6 +26,7 @@ request helpers feature.
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'sinatra', '>= 1.0', '< 3'
   s.add_development_dependency 'rdoc', '~> 5.1'
+  s.add_development_dependency 'rubocop', '>= 0.49', '< 0.50'
   # Keep version < 1 to supress deprecated warning temporary.
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
   # For Thorfile. Run "bundle exec thor help" to see the help.


### PR DESCRIPTION
Hi,

I want to add `rubocop` task in `Rakefile`.

```
$ bundle install --path vendor/bundle

$ bundle list | grep rubocop
  * rubocop (0.49.1)

$ bundle exec rake -T
rake docs                  # Generate RDoc
rake rubocop               # Run RuboCop
rake rubocop:auto_correct  # Auto-correct RuboCop offenses
rake spec                  # Run RSpec code examples
rake whitespace            # Removes trailing whitespace

$ bundle exec rake rubocop
...
24 files inspected, 1763 offenses detected
RuboCop failed!
```

We can fix an adjust one by one :)

