### PR TITLE
Update to prevent test failure for UploadedFile GC test on JRuby.

### DIFF
--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -41,7 +41,7 @@ describe Rack::Test::UploadedFile do
         require 'java'
         java_import 'java.lang.System'
 
-        20.times do |i|
+        50.times do |i|
           uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
           uploaded_file = nil


### PR DESCRIPTION
Because the test sometimes fails.

Maybe we need more reliable test than this PR's implementation in the future.
But right now I have no idea to fix this.
