### PR TITLE
Bugfix for Cookies with multiple paths

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -53,7 +53,7 @@ module Rack
 
       # :api: private
       def path
-        @options['path'].strip || '/'
+        ([*@options['path']].first.split(',').first || '/').strip
       end
 
       # :api: private

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -28,7 +28,7 @@ describe Rack::Test::Session do
       expect(last_request.cookies).to eq({})
     end
 
-    it 'uses the first "path" when many paths is defined when given many paths' do
+    it 'uses the first "path" when multiple paths are defined' do
       cookie_string = [
         '/',
         'csrf_id=ABC123',
@@ -41,7 +41,7 @@ describe Rack::Test::Session do
       expect(cookie.path).to eq('/')
     end
 
-    it 'uses the first path when many paths is defined' do
+    it 'uses the single "path" when only one path is defined' do
       cookie_string = [
         '/',
         'csrf_id=ABC123',

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -28,6 +28,31 @@ describe Rack::Test::Session do
       expect(last_request.cookies).to eq({})
     end
 
+    it 'uses the first "path" when many paths is defined when given many paths' do
+      cookie_string = [
+        '/',
+        'csrf_id=ABC123',
+        'path=/, _github_ses=ABC123',
+        'path=/',
+        'expires=Wed, 01 Jan 2020 08:00:00 GMT',
+        'HttpOnly'
+      ].join('; ')
+      cookie = Rack::Test::Cookie.new(cookie_string)
+      expect(cookie.path).to eq('/')
+    end
+
+    it 'uses the first path when many paths is defined' do
+      cookie_string = [
+        '/',
+        'csrf_id=ABC123',
+        'path=/',
+        'expires=Wed, 01 Jan 2020 08:00:00 GMT',
+        'HttpOnly'
+      ].join('; ')
+      cookie = Rack::Test::Cookie.new(cookie_string)
+      expect(cookie.path).to eq('/')
+    end
+
     it 'escapes cookie values' do
       jar = Rack::Test::CookieJar.new
       jar['value'] = 'foo;abc'
@@ -45,7 +70,7 @@ describe Rack::Test::Session do
     it 'allow symbol access' do
       jar = Rack::Test::CookieJar.new
       jar['value'] = 'foo;abc'
-      jar[:value].should == 'foo;abc'
+      expect(jar[:value]).to eq('foo;abc')
     end
 
     it "doesn't send cookies with the wrong domain" do

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -56,7 +56,7 @@ describe Rack::Test::UploadedFile do
 
         it 'sets the specified filename' do
           subject.call
-          uploaded_file.original_filename.should == original_filename
+          expect(uploaded_file.original_filename).to eq(original_filename)
         end
       end
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -129,7 +129,7 @@ describe Rack::Test::Session do
 
     it 'does not rewrite a GET query string when :params is empty' do
       request '/foo?a=1&b=2&c=3&e=4&d=5', params: {}
-      last_request.query_string.should == 'a=1&b=2&c=3&e=4&d=5'
+      expect(last_request.query_string).to eq('a=1&b=2&c=3&e=4&d=5')
     end
 
     it 'does not overwrite multiple query string keys' do
@@ -391,9 +391,9 @@ describe Rack::Test::Session do
       it 'keeps the original method' do
         post '/redirect?status=307', foo: 'bar'
         follow_redirect!
-        last_response.body.should include 'post'
-        last_response.body.should include 'foo'
-        last_response.body.should include 'bar'
+        expect(last_response.body).to include('post')
+        expect(last_response.body).to include('foo')
+        expect(last_response.body).to include('bar')
       end
     end
   end


### PR DESCRIPTION
closes #16 "Rack::Test::CookieJar cannot handle multiple 'path' values in the Cookie."

However this is not a valid cookie string, I've found some web servers that ignore this and still deliver multiple keys. 

http://www.w3.org/Protocols/rfc2109/rfc2109

4.2.2  Set-Cookie Syntax

```
... If an attribute appears more than once in a cookie, the behavior is undefined. ...
```

rebased after notification from #92 