### PR TITLE
Create tempfile using the basename without extension:

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -62,8 +62,9 @@ module Rack
         raise "#{path} file does not exist" unless ::File.exist?(path)
 
         @original_filename = ::File.basename(path)
+        extension = ::File.extname(@original_filename)
 
-        @tempfile = Tempfile.new([@original_filename, ::File.extname(path)])
+        @tempfile = Tempfile.new([::File.basename(@original_filename, extension), extension])
         @tempfile.set_encoding(Encoding::BINARY) if @tempfile.respond_to?(:set_encoding)
 
         ObjectSpace.define_finalizer(self, self.class.finalize(@tempfile))

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -28,7 +28,8 @@ describe Rack::Test::UploadedFile do
   it 'creates Tempfiles with a path that includes a single extension' do
     uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
 
-    expect(uploaded_file.path).to_not match(/foo.txt/)
+    regex = /foo#{Time.now.year}.*\.txt\Z/
+    expect(uploaded_file.path).to match(regex)
   end
 
   context 'it should call its destructor' do

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -25,6 +25,12 @@ describe Rack::Test::UploadedFile do
     expect(File.extname(uploaded_file.path)).to eq('.txt')
   end
 
+  it 'creates Tempfiles with a path that includes a single extension' do
+    uploaded_file = Rack::Test::UploadedFile.new(test_file_path)
+
+    expect(uploaded_file.path).to_not match(/foo.txt/)
+  end
+
   context 'it should call its destructor' do
     it 'calls the destructor' do
       expect(Rack::Test::UploadedFile).to receive(:actually_finalize).at_least(:once)


### PR DESCRIPTION
👋  Hello guys, thanks for creating and maintaining this gem

- 5f7845118f649b60862a9bc01f6b2a0f932e89d7 a.k.a #129 introduced a change to keep the filename extension when creating the tempfile
- `Tempfile#path` is now returning the filename with the extension followed by random chars and the extension again
```ruby
puts Rack::Test::UploadedFile.new('foo.txt').path # => '/var/xxx/foo.txt2017-30-08-dsad.txt'
```
- This PR modifies this behaviour to not include the file extension as part of the file basename when creating the Tempfile