### PR TITLE
Do not set Content-Type if params are explicitly set to nil

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -217,7 +217,7 @@ module Rack
         # Stringifying and upcasing methods has be commit upstream
         env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
 
-        params = env.delete(:params, {})
+        params = env.delete(:params) do {} end
 
         if env['REQUEST_METHOD'] == 'GET'
           # merge :params with the query string

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -217,7 +217,7 @@ module Rack
         # Stringifying and upcasing methods has be commit upstream
         env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
 
-        params = env.delete(:params) { {} }
+        params = env.delete(:params, {})
 
         if env['REQUEST_METHOD'] == 'GET'
           # merge :params with the query string

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -217,30 +217,30 @@ module Rack
         # Stringifying and upcasing methods has be commit upstream
         env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
 
-        if %w[GET DELETE].include?(env['REQUEST_METHOD'])
+        params = env.delete(:params) { {} }
+
+        if env['REQUEST_METHOD'] == 'GET'
           # merge :params with the query string
-          if params = env[:params]
+          if params
             params = parse_nested_query(params) if params.is_a?(String)
 
             uri.query = [uri.query, build_nested_query(params)].compact.reject { |v| v == '' }.join('&')
           end
         elsif !env.key?(:input)
-          env['CONTENT_TYPE'] ||= 'application/x-www-form-urlencoded'
+          env['CONTENT_TYPE'] ||= 'application/x-www-form-urlencoded' unless params.nil?
 
-          if env[:params].is_a?(Hash)
-            if data = build_multipart(env[:params])
+          if params.is_a?(Hash)
+            if data = build_multipart(params)
               env[:input] = data
               env['CONTENT_LENGTH'] ||= data.length.to_s
               env['CONTENT_TYPE'] = "multipart/form-data; boundary=#{MULTIPART_BOUNDARY}"
             else
-              env[:input] = params_to_string(env[:params])
+              env[:input] = params_to_string(params)
             end
           else
-            env[:input] = env[:params]
+            env[:input] = params
           end
         end
-
-        env.delete(:params)
 
         set_cookie(env.delete(:cookie), uri) if env.key?(:cookie)
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -463,6 +463,11 @@ describe Rack::Test::Session do
       expect(last_request.env['HTTP_USER_AGENT']).to eq('Rack::Test')
     end
 
+    it 'does not set CONTENT_TYPE if params are explicitly set to nil' do
+      public_send(verb, '/', nil)
+      expect(last_request.env['CONTENT_TYPE']).to be_nil
+    end
+
     it 'yields the response to a given block' do
       yielded = false
 
@@ -600,12 +605,6 @@ describe Rack::Test::Session do
 
     def verb
       'delete'
-    end
-
-    it 'does not set a content type' do
-      delete '/'
-
-      expect(last_request.env['CONTENT_TYPE']).to be_nil
     end
   end
 


### PR DESCRIPTION
The breaking change was introduced with d016695d84dd2e9b09eb77e5a89ffcbc1892921a that disallows to send the payload with DELETE requests.

Make the request method skip setting default Content-Type header if params are explicitly set to `nil`.

It solves the problem from the #200, keeping a way to achieve goal requested in #132.