### PR TITLE
Fix UploadedFile#new regression

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -25,11 +25,11 @@ module Rack
       #   file.
       # @param content_type [String]
       # @param binary [Boolean] an optional flag that indicates whether the file should be open in binary mode or not.
-      # @param original_filename [String] an optional parameter that provides the original filename if `content` is an IO
-      #   object.
+      # @param original_filename [String] an optional parameter that provides the original filename if `content` is a StringIO
+      #   object. Not used for other kind of `content` objects.
       def initialize(content, content_type = 'text/plain', binary = false, original_filename: nil)
-        if content.respond_to?(:read) && (content.is_a?(IO) || content.is_a?(StringIO))
-          initialize_from_io(content, original_filename)
+        if original_filename
+          initialize_from_stringio(content, original_filename)
         else
           initialize_from_file_path(content)
         end
@@ -62,9 +62,9 @@ module Rack
 
       private
 
-      def initialize_from_io(io, original_filename)
-        @tempfile = io
-        @original_filename = original_filename || raise(ArgumentError, 'Missing `original_filename` for IO')
+      def initialize_from_stringio(stringio, original_filename)
+        @tempfile = stringio
+        @original_filename = original_filename || raise(ArgumentError, 'Missing `original_filename` for StringIO object')
       end
 
       def initialize_from_file_path(path)

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -45,11 +45,10 @@ describe Rack::Test::UploadedFile do
   end
 
   describe '#initialize' do
-    subject { -> { uploaded_file } }
-    let(:uploaded_file) { described_class.new(io, original_filename: original_filename) }
-
     context 'with an IO object' do
-      let(:io) { StringIO.new('I am content') }
+      let(:stringio) { StringIO.new('I am content') }
+      let(:uploaded_file) { described_class.new(stringio, original_filename: original_filename) }
+      subject { -> { uploaded_file } }
 
       context 'with an original filename' do
         let(:original_filename) { 'content.txt' }
@@ -58,11 +57,6 @@ describe Rack::Test::UploadedFile do
           subject.call
           expect(uploaded_file.original_filename).to eq(original_filename)
         end
-      end
-
-      context 'without an original filename' do
-        let(:original_filename) { nil }
-        it { should raise_error(ArgumentError) }
       end
     end
   end


### PR DESCRIPTION
In #210, we tried to fix this but the fix was perhaps not really good enough... So let's relax this check a bit and hopefully unbreak these use cases.

@aebirim, please try the following in your application's `Gemfile` to see if this now resolves the problem you were seeing.

```ruby
gem 'rack-test', github: 'rack-test', branch: 'fix/uploaded-file-regression-v2'`
```

@junaruga and/or @scepticulous, please review.

Closes #211 