### PR TITLE
Save `session` during `follow_redirect!`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 166
+  Max: 172
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@
 
 * Minor enhancements
   * Save `session` during `follow_redirect!`
+    (Alexander Popov #218)
 
 ## 0.8.2 / 2017-11-21
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+## master
+
+* Minor enhancements
+  * Save `session` during `follow_redirect!`
+
 ## 0.8.2 / 2017-11-21
 
 * Bug fixes:

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -188,11 +188,17 @@ module Rack
         unless last_response.redirect?
           raise Error, 'Last response was not a redirect. Cannot follow_redirect!'
         end
-        if last_response.status == 307
-          send(last_request.request_method.downcase.to_sym, last_response['Location'], last_request.params, 'HTTP_REFERER' => last_request.url)
-        else
-          get(last_response['Location'], {}, 'HTTP_REFERER' => last_request.url)
-        end
+        request_method, params =
+          if last_response.status == 307
+            [last_request.request_method.downcase.to_sym, last_request.params]
+          else
+            [:get, {}]
+          end
+        send(
+          request_method, last_response['Location'], params,
+          'HTTP_REFERER' => last_request.url,
+          'rack.session' => last_request.session
+        )
       end
 
       private

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -30,7 +30,7 @@ module Rack
 
       %i[get put post delete].each do |meth|
         send(meth, '/redirected') do
-          additional_info = meth == :get ? '' : " using #{meth} with #{params}"
+          additional_info = meth == :get ? ", session #{session}" : " using #{meth} with #{params}"
           "You've been redirected" + additional_info
         end
       end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -362,7 +362,7 @@ describe Rack::Test::Session do
       follow_redirect!
 
       expect(last_response).not_to be_redirect
-      expect(last_response.body).to eq("You've been redirected")
+      expect(last_response.body).to eq("You've been redirected, session {}")
       expect(last_request.env['HTTP_REFERER']).to eql('http://example.org/redirect')
     end
 
@@ -371,6 +371,13 @@ describe Rack::Test::Session do
       follow_redirect!
 
       expect(last_request.GET).to eq({})
+    end
+
+    it 'includes session when following the redirect' do
+      get '/redirect', {}, 'rack.session' => { 'foo' => 'bar' }
+      follow_redirect!
+
+      expect(last_response.body).to include('session {"foo"=>"bar"}')
     end
 
     it 'raises an error if the last_response is not set' do


### PR DESCRIPTION
It's helpful (and necessary) for tests of actions with session modifications and redirects
(redirects + flashes, for example).