### PR TITLE
RFC 6265 adjustment: Delimit cookies by semicolon and single space

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -106,6 +106,8 @@ module Rack
     end
 
     class CookieJar # :nodoc:
+      DELIMITER = '; '.freeze
+
       # :api: private
       def initialize(cookies = [], default_host = DEFAULT_HOST)
         @default_host = default_host
@@ -158,7 +160,7 @@ module Rack
 
       # :api: private
       def for(uri)
-        hash_for(uri).values.map(&:raw).join(';')
+        hash_for(uri).values.map(&:raw).join(DELIMITER)
       end
 
       def to_hash

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -18,4 +18,13 @@ describe Rack::Test::CookieJar do
       end
     end
   end
+
+  describe '#for' do
+    it 'returns the cookie header string delimited by semicolon and a space' do
+      jar['a'] = 'b'
+      jar['c'] = 'd'
+
+      expect(jar.for(nil)).to eq('a=b; c=d')
+    end
+  end
 end

--- a/spec/rack/test/cookie_object_spec.rb
+++ b/spec/rack/test/cookie_object_spec.rb
@@ -11,15 +11,15 @@ describe Rack::Test::Cookie do
       'domain=' + domain,
       'path=' + path,
       'expires=' + expires
-    ].join('; ')
+    ].join(Rack::Test::CookieJar::DELIMITER)
   end
 
   let(:http_only_raw_cookie_string) do
-    raw_cookie_string + '; HttpOnly'
+    raw_cookie_string + Rack::Test::CookieJar::DELIMITER + 'HttpOnly'
   end
 
   let(:http_only_secure_raw_cookie_string) do
-    http_only_raw_cookie_string + '; secure'
+    http_only_raw_cookie_string + Rack::Test::CookieJar::DELIMITER + 'secure'
   end
 
   let(:value) { 'the cookie value' }

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -36,7 +36,7 @@ describe Rack::Test::Session do
         'path=/',
         'expires=Wed, 01 Jan 2020 08:00:00 GMT',
         'HttpOnly'
-      ].join('; ')
+      ].join(Rack::Test::CookieJar::DELIMITER)
       cookie = Rack::Test::Cookie.new(cookie_string)
       expect(cookie.path).to eq('/')
     end
@@ -48,7 +48,7 @@ describe Rack::Test::Session do
         'path=/',
         'expires=Wed, 01 Jan 2020 08:00:00 GMT',
         'HttpOnly'
-      ].join('; ')
+      ].join(Rack::Test::CookieJar::DELIMITER)
       cookie = Rack::Test::Cookie.new(cookie_string)
       expect(cookie.path).to eq('/')
     end


### PR DESCRIPTION
[rfc 6265 section 4.2.1](https://tools.ietf.org/html/rfc6265#section-4.2.1) specifies the grammar of the cookie header to have a delimiter of a single space between semicolon and the next cookie pair. also went ahead and made replacements for the delimiter where it seemed fit.