### PR TITLE
Always set CONTENT_TYPE for non-GET requests

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -233,7 +233,7 @@ module Rack
             uri.query = [uri.query, build_nested_query(params)].compact.reject { |v| v == '' }.join('&')
           end
         elsif !env.key?(:input)
-          env['CONTENT_TYPE'] ||= 'application/x-www-form-urlencoded' unless params.nil?
+          env['CONTENT_TYPE'] ||= 'application/x-www-form-urlencoded'
 
           if params.is_a?(Hash)
             if data = build_multipart(params)
@@ -241,6 +241,8 @@ module Rack
               env['CONTENT_LENGTH'] ||= data.length.to_s
               env['CONTENT_TYPE'] = "multipart/form-data; boundary=#{MULTIPART_BOUNDARY}"
             else
+              # NB: We do not need to set CONTENT_LENGTH here;
+              # Rack::ContentLength will determine it automatically.
               env[:input] = params_to_string(params)
             end
           else


### PR DESCRIPTION
...even when no parameters are provided (or the provided parameters are `nil`)

The long story:

- https://github.com/rack-test/rack-test/pull/132 changed the behavior for HTTP DELETE requests to behave like GET: put the parameters in the query string, and don't set the Content-Type. This change was merged in https://github.com/rack-test/rack-test/commit/d016695d84dd2e9b09eb77e5a89ffcbc1892921a
- This broke `rack-test` for certain people, which was highlighted in https://github.com/rack-test/rack-test/issues/200. Arguably, the change incorporated in https://github.com/rack-test/rack-test/commit/d016695d84dd2e9b09eb77e5a89ffcbc1892921a was too brutal.
- https://github.com/rack-test/rack-test/pull/212 tried to sort it out, by not setting Content-Type if params are nil, and also reverting the change to put DELETE parameters in the query string. The first part of this (params being nil) caused issues for certain people.

So this PR now tries to once and for all sort this out by:

- Always setting `env['CONTENT_TYPE']`, even when params are `nil`.
- Adding more tests for how `CONTENT_TYPE` and `CONTENT_LENGTH` should behave; some of this does not come from us, but from Rack upstream.
- Settles with the discussion in https://github.com/rack-test/rack-test/pull/220: if you are using `DELETE` and must use query params, put them manually in there like this: `delete '/foo?bar=baz'`. Arguably not very clean, but better than changing back and forth. `params` are overloaded in rack 0.x and will be so in 1.0 also. I am thinking that we should go with the excellent suggestion provided by @malacalypse in #200 to use dedicated `body` and `params` parameters in the long run (and probably use keyword parameters instead, but that's definitely a 2.x feature since it breaks all existing usage.) For now, I think we'll live with the ugliness.

I encourage everyone to give this a try before we merge, to ensure we don't have to revert once more. I plan on waiting with the merge until sometime next week because of this.

Ping @mwpastore @junaruga @scepticulous @barthez @rafaelfranca @tpltn @joshashby et al.

----

Oh, and one more thing: if you need the behavior in #132, to not have the Content-Type set for DELETE requests - please change your code to check if `Content-Length` is zero. If it is, don't try to parse the request body. Because of the slight pain these changes have inflicted on the community, I will **refuse** further PRs that tries to reintroduce that behavior; if this causes problems for you, it's unfortunately your code or app that has to change. Each version of rack-test released gets downloaded [hundreds of thousands of times](https://rubygems.org/gems/rack-test), so it is actually good thing if it doesn't move too fast. (but, as implied above, I'm hoping we can release a _clearly-marked-as-such_ version 2.0 at some point with some nice improvements that do break a bit of b/c)