### PR TITLE
Sets up focus filter for tests and fixes inconsistency

### DIFF
--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -341,7 +341,7 @@ describe Rack::Test::Session do
 
   describe '#basic_authorize' do
     it 'sets the HTTP_AUTHORIZATION header' do
-      authorize 'bryan', 'secret'
+      basic_authorize 'bryan', 'secret'
       request '/'
 
       expect(last_request.env['HTTP_AUTHORIZATION']).to eq('Basic YnJ5YW46c2VjcmV0')
@@ -446,7 +446,7 @@ describe Rack::Test::Session do
       expect(last_response['Content-Type']).to eq('text/html;charset=utf-8')
     end
 
-    it 'raises an error if no requests have been issued', focus: true do
+    it 'raises an error if no requests have been issued' do
       expect do
         last_response
       end.to raise_error(Rack::Test::Error)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ RSpec.configure do |config|
   config.mock_with :rspec
   config.include Rack::Test::Methods
 
+  config.filter_run_when_matching :focus
+
   def app
     Rack::Lint.new(Rack::Test::FakeApp.new)
   end


### PR DESCRIPTION
In order to focus on single tests during development rspec supports
the option `filter_run_when_matching`.
We agreed, that it is fine for us to support this in #235.

Since it is important to not push :focus tags to the sourcetree,
a leftover has been removed `focus: true`.

Finally an inconsistency in the use of `basic_authorize` and
`authorize` has been fixed.
This has additional value, since this PR is the base for PR #235,
which is supposed to add more tests for digest_authorization.
Since we will have different ways to authorize, it is very helpful
to make the method explicit within our tests.