### PR TITLE
Retry to download code climate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
       gem install bundler
     fi
 before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - travis_retry curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:


### PR DESCRIPTION
I started to run Travis CI on daily cron mode too as an experiment days ago.
Then I faced below error today.
Let's make the CI robust to retry downloading.

https://travis-ci.org/rack-test/rack-test/builds/496755691
https://travis-ci.org/rack-test/rack-test/jobs/496755699

```
$ curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
curl: (56) SSL read: error:00000000:lib(0):func(0):reason(0), errno 104
The command "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter" failed and exited with 56 during .
```

