### PR TITLE
Add IRC notification for a Travis CI build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,11 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
   fast_finish: true
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#rack-test"
+    on_success: change # [always|never|change] # default: always
+    on_failure: always # [always|never|change] # default: always
+    template:
+      - "%{message} by @%{author}: See %{build_url}"


### PR DESCRIPTION
As we enabled Travis daily cron mode to run, shall we enable the notification for a freenode IRC server "rack-test" channel?
I try to join the channel, and care about it. It's better than current situation isn't it?
And if you are using Slack, I suppose that you can also connect to the IRC server.

Ref https://github.com/ruby/ruby/blob/trunk/.travis.yml#L387-L395
