### PR TITLE
Remove deprecated TODO

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -226,8 +226,6 @@ module Rack
         env.update('HTTPS' => 'on') if URI::HTTPS === uri
         env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if env[:xhr]
 
-        # TODO: Remove this after Rack 1.1 has been released.
-        # Stringifying and upcasing methods has be commit upstream
         env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
 
         params = env.delete(:params) do {} end


### PR DESCRIPTION
I think @josh talked about https://github.com/rack/rack/blob/1.1/lib/rack/mock.rb#L80. But even though we're far past rack 1.1 now, we still have symbols in here.

Rewriting to `env['REQUEST_METHOD'] ||= env[:method] || 'GET'` makes the tests fail.