### PR TITLE
add spec for converting empty arrays when building nested queries

### DIFF
--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -25,6 +25,10 @@ describe Rack::Test::Utils do
       expect(['a=1&b=2', 'b=2&a=1']).to include(build_nested_query(hash))
     end
 
+    it 'converts empty arrays' do
+      expect(build_nested_query(a: [])).to eq('a[]=')
+    end
+
     it 'converts arrays with one element' do
       expect(build_nested_query(a: [1])).to eq('a[]=1')
     end


### PR DESCRIPTION
### what did you do?
Adds a very basic spec for testing empty arrays.

### why?
Scanning through the specs it wasn't immediately obvious how empty arrays were going to be handled as the only spec we have for it is for empty arrays nested in a hash.

This [commit](https://github.com/rack-test/rack-test/commit/ece681de8ffee9d0caff30e9b93f882cc58f14cb) changed the functionality but only added a spec for hash types which is a slightly different flow as we check for the type [here](https://github.com/rack-test/rack-test/blob/master/lib/rack/test/utils.rb#L9)