### PR TITLE
Remove symbol support for request method

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -226,9 +226,7 @@ module Rack
         env.update('HTTPS' => 'on') if URI::HTTPS === uri
         env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if env[:xhr]
 
-        # TODO: Remove this after Rack 1.1 has been released.
-        # Stringifying and upcasing methods has be commit upstream
-        env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
+        env['REQUEST_METHOD'] ||= env[:method] || 'GET'
 
         params = env.delete(:params) do {} end
 

--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -22,7 +22,7 @@ request helpers feature.
   s.files = `git ls-files -- lib/*`.split("\n") +
             %w[History.md MIT-LICENSE.txt README.md]
   s.required_ruby_version = '>= 2.2.2'
-  s.add_dependency 'rack', '>= 1.0', '< 3'
+  s.add_dependency 'rack', '>= 1.1', '< 3'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'sinatra', '>= 1.0', '< 3'

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -93,13 +93,8 @@ describe Rack::Test::Session do
     end
 
     it 'allows passing :input in for POSTs' do
-      request '/', method: :post, input: 'foo'
+      request '/', method: 'POST', input: 'foo'
       expect(last_request.env['rack.input'].read).to eq('foo')
-    end
-
-    it 'converts method names to a uppercase strings' do
-      request '/', method: :put
-      expect(last_request.env['REQUEST_METHOD']).to eq('PUT')
     end
 
     it 'prepends a slash to the URI path' do
@@ -138,12 +133,12 @@ describe Rack::Test::Session do
     end
 
     it 'accepts params and builds url encoded params for POST requests' do
-      request '/foo', method: :post, params: { foo: { bar: '1' } }
+      request '/foo', method: 'POST', params: { foo: { bar: '1' } }
       expect(last_request.env['rack.input'].read).to eq('foo[bar]=1')
     end
 
     it 'accepts raw input in params for POST requests' do
-      request '/foo', method: :post, params: 'foo[bar]=1'
+      request '/foo', method: 'POST', params: 'foo[bar]=1'
       expect(last_request.env['rack.input'].read).to eq('foo[bar]=1')
     end
 


### PR DESCRIPTION
**Beware** that this could break for people who use `request` directly. Even though `request` is undocumented, it's publicly available.

**But**: Other than that, there's no need to support symbols because _Rack_ only uses uppercase strings: <https://github.com/rack/rack/blob/1.1/lib/rack/mock.rb#L80>

I only tested it with `rack` 1.6 and newer. But it should work back to 1.1 (do we still guarantee that?).