### PR TITLE
Read uploaded file without modifying descriptor offset

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -128,14 +128,15 @@ EOF
       module_function :build_primitive_part
 
       def build_file_part(parameter_name, uploaded_file)
+        uploaded_file_size = uploaded_file.size
         uploaded_file.set_encoding(Encoding::BINARY) if uploaded_file.respond_to?(:set_encoding)
         <<-EOF
 --#{MULTIPART_BOUNDARY}\r
 Content-Disposition: form-data; name="#{parameter_name}"; filename="#{escape(uploaded_file.original_filename)}"\r
 Content-Type: #{uploaded_file.content_type}\r
-Content-Length: #{uploaded_file.size}\r
+Content-Length: #{uploaded_file_size}\r
 \r
-#{uploaded_file.read}\r
+#{uploaded_file.pread(uploaded_file_size, 0)}\r
 EOF
       end
       module_function :build_file_part

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -69,7 +69,8 @@ describe Rack::Test::Utils do
       params = Rack::Multipart.parse_multipart(env)
       check expect(params['submit-name']).to eq('Larry')
       check expect(params['files'][:filename]).to eq('foo.txt')
-      expect(params['files'][:tempfile].read).to eq("bar\n")
+      expect(files.pos).to eq(0)
+      expect(params['files'][:tempfile].read).to eq(files.read)
     end
 
     it 'builds multipart bodies from array of files' do


### PR DESCRIPTION
Hi, 
After upgrading `rack-test` from `0.6.3` to `1.1.0` we got several failed tests relying on `Rack::Test::UploadedFile`. I think the issue related to this [line](https://github.com/rack/rack-test/blob/master/lib/rack/test/utils.rb#L138). After calling `read` on uploaded file it moves file descriptor offset to the end of the file. So, I hope this PR should fix the problem