### PR TITLE
Add compatibility with rack 2.1.0

### DIFF
--- a/lib/rack/mock_session.rb
+++ b/lib/rack/mock_session.rb
@@ -26,7 +26,7 @@ module Rack
     def request(uri, env)
       env['HTTP_COOKIE'] ||= cookie_jar.for(uri)
       @last_request = Rack::Request.new(env)
-      status, headers, body = @app.call(@last_request.env)
+      status, headers, body = @app.call(@last_request.env).to_a
 
       @last_response = MockResponse.new(status, headers, body, env['rack.errors'].flush)
 

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -147,6 +147,15 @@ describe Rack::Test::Session do
       expect(last_request.env['rack.input'].read).to eq('foo[bar]=1')
     end
 
+    it 'supports a Rack::Response' do
+      app = lambda do |_env|
+        Rack::Response.new('', 200, {})
+      end
+
+      session = Rack::Test::Session.new(Rack::MockSession.new(app))
+      expect(session.request('/')).to be_ok
+    end
+
     context 'when the response body responds_to?(:close)' do
       class CloseableBody
         def initialize


### PR DESCRIPTION
This PR adds support for Rack 2.1.0 by fixing a breaking change that affected users of rack-test:

- [Remove to_ary from Response](https://github.com/rack/rack/commit/bf0e41dc79bd0e7ca21bc077f122ed446e2de03c)