### PR TITLE
Fix file parts not built properly when put in a array with primitives

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -97,18 +97,14 @@ module Rack
               get_parts(new_value).join
             end.join
           else
-            if value.respond_to?(:original_filename)
-              build_file_part(name, value)
-
-            elsif value.is_a?(Array) && value.all? { |v| v.respond_to?(:original_filename) }
-              value.map do |v|
+            [value].flatten.map do |v|
+              if v.respond_to?(:original_filename)
                 build_file_part(name, v)
-              end.join
-
-            else
-              primitive_part = build_primitive_part(name, value)
-              Rack::Test.encoding_aware_strings? ? primitive_part.force_encoding('BINARY') : primitive_part
-            end
+              else
+                primitive_part = build_primitive_part(name, v)
+                Rack::Test.encoding_aware_strings? ? primitive_part.force_encoding('BINARY') : primitive_part
+              end
+            end.join
           end
         end
       end


### PR DESCRIPTION
Current implementation of `Rack::Test::Utils#get_parts` can handle an array with files [only if the array is made purely of files](https://github.com/rack/rack-test/blob/9ddc2539f7d6447f19582ac11fe4dd80f6a8fad1/lib/rack/test/utils.rb#L103), thus mixing files and strings together in a array produces params like:

```
{"field_test"=>{"carrierwave_assets"=>["", "#<Rack::Test::UploadedFile:0x00000001284b85d8>", "#<Rack::Test::UploadedFile:0x00000001289dd450>"]}, "return_to"=>"", "_save"=>""}
```

where `#<Rack::Test::UploadedFile ... >` is just a string representation of the Rack::Test::UploadedFile instance, not the actual one.

So I've applied a fix to #get_parts to handle primitives in arrays properly.

It'd be great if this could be merged in, thanks in advance!