### PR TITLE
Fix: validate StringIO args on UploadedFile.new

### DIFF
--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -28,11 +28,13 @@ module Rack
       # @param original_filename [String] an optional parameter that provides the original filename if `content` is a StringIO
       #   object. Not used for other kind of `content` objects.
       def initialize(content, content_type = 'text/plain', binary = false, original_filename: nil)
-        if original_filename
+        case content
+        when StringIO
           initialize_from_stringio(content, original_filename)
         else
           initialize_from_file_path(content)
         end
+
         @content_type = content_type
         @tempfile.binmode if binary
       end

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -54,15 +54,23 @@ describe Rack::Test::UploadedFile do
   describe '#initialize' do
     context 'with an IO object' do
       let(:stringio) { StringIO.new('I am content') }
-      let(:uploaded_file) { described_class.new(stringio, original_filename: original_filename) }
       subject { -> { uploaded_file } }
 
       context 'with an original filename' do
         let(:original_filename) { 'content.txt' }
+        let(:uploaded_file) { described_class.new(stringio, original_filename: original_filename) }
 
         it 'sets the specified filename' do
           subject.call
           expect(uploaded_file.original_filename).to eq(original_filename)
+        end
+      end
+
+      context 'without an original filename' do
+        let(:uploaded_file) { described_class.new(stringio) }
+
+        it 'raises an error' do
+          expect { subject.call }.to raise_error(ArgumentError, 'Missing `original_filename` for StringIO object')
         end
       end
     end


### PR DESCRIPTION
`UploadedFile` includes two initialization strategies - it can either be built by passing as `content` a file-ish object (`initialize_from_file_path`) or a `StringIO` instance (`initialize_from_stringio`).

The initializer switches on the presence of the `original_filename` kwarg to decide which strategy to use. If present, it assumes the user wants to provide contents via `StringIO`.

However, as `initialize_from_stringio` suggests initialization should fail with an `ArgumentError` if `original_filename` isn't provided, it seems that the init strategy selection is currently incorrect.

Fix by actually switching init strategy on the type of the `content` argument and add missing test to check the `ArgumentError` is really raised.