### PR TITLE
Revert "Remove symbol support for request method"

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -226,7 +226,9 @@ module Rack
         env.update('HTTPS' => 'on') if URI::HTTPS === uri
         env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest' if env[:xhr]
 
-        env['REQUEST_METHOD'] ||= env[:method] || 'GET'
+        # TODO: Remove this after Rack 1.1 has been released.
+        # Stringifying and upcasing methods has be commit upstream
+        env['REQUEST_METHOD'] ||= env[:method] ? env[:method].to_s.upcase : 'GET'
 
         params = env.delete(:params) do {} end
 

--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -22,7 +22,7 @@ request helpers feature.
   s.files = `git ls-files -- lib/*`.split("\n") +
             %w[History.md MIT-LICENSE.txt README.md]
   s.required_ruby_version = '>= 2.2.2'
-  s.add_dependency 'rack', '>= 1.1', '< 3'
+  s.add_dependency 'rack', '>= 1.0', '< 3'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'sinatra', '>= 1.0', '< 3'

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -93,8 +93,13 @@ describe Rack::Test::Session do
     end
 
     it 'allows passing :input in for POSTs' do
-      request '/', method: 'POST', input: 'foo'
+      request '/', method: :post, input: 'foo'
       expect(last_request.env['rack.input'].read).to eq('foo')
+    end
+
+    it 'converts method names to a uppercase strings' do
+      request '/', method: :put
+      expect(last_request.env['REQUEST_METHOD']).to eq('PUT')
     end
 
     it 'prepends a slash to the URI path' do
@@ -133,12 +138,12 @@ describe Rack::Test::Session do
     end
 
     it 'accepts params and builds url encoded params for POST requests' do
-      request '/foo', method: 'POST', params: { foo: { bar: '1' } }
+      request '/foo', method: :post, params: { foo: { bar: '1' } }
       expect(last_request.env['rack.input'].read).to eq('foo[bar]=1')
     end
 
     it 'accepts raw input in params for POST requests' do
-      request '/foo', method: 'POST', params: 'foo[bar]=1'
+      request '/foo', method: :post, params: 'foo[bar]=1'
       expect(last_request.env['rack.input'].read).to eq('foo[bar]=1')
     end
 


### PR DESCRIPTION
This reverts commit c90fb05e9df18d381b673c3c0bf2663019186141.

After reading the rack code more closely, I no longer think this
is a good idea.  This makes the behavior inconsistent with
Rack::Mock (which does the symbol->upcase string conversion), and
I don't think it's worth the backwards compatibility breakage.