### PR TITLE
Add support for :query_params to set query parameters for non-GET requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,8 +28,14 @@ Metrics/BlockLength:
     - spec/**/*
     - rack-test.gemspec
 
-# Rationale: Enforcing maximum module length makes code worse, without exception
+# Rationale: Enforcing maximum length/complexity makes code worse, without exception
 Metrics/ModuleLength:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false
 
 # Rationale: allow Weirich-style blocks, but do not enforce them.

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -81,9 +81,36 @@ describe Rack::Test::Session do
       end
     end
 
-    it 'supports sending :params' do
+    it 'supports sending :params for GET' do
       request '/', params: { 'foo' => 'bar' }
       expect(last_request.GET['foo']).to eq('bar')
+    end
+
+    it 'supports sending :query_params for GET' do
+      request '/', query_params: { 'foo' => 'bar' }
+      expect(last_request.GET['foo']).to eq('bar')
+    end
+
+    it 'supports sending both :params and :query_params for GET' do
+      request '/', query_params: { 'foo' => 'bar' }, params: { 'foo2' => 'bar2' }
+      expect(last_request.GET['foo']).to eq('bar')
+      expect(last_request.GET['foo2']).to eq('bar2')
+    end
+
+    it 'supports sending :params for POST' do
+      request '/', method: :post, params: { 'foo' => 'bar' }
+      expect(last_request.POST['foo']).to eq('bar')
+    end
+
+    it 'supports sending :query_params for POST' do
+      request '/', method: :post, query_params: { 'foo' => 'bar' }
+      expect(last_request.GET['foo']).to eq('bar')
+    end
+
+    it 'supports sending both :params and :query_params for POST' do
+      request '/', method: :post, query_params: { 'foo' => 'bar' }, params: { 'foo2' => 'bar2' }
+      expect(last_request.GET['foo']).to eq('bar')
+      expect(last_request.POST['foo2']).to eq('bar2')
     end
 
     it "doesn't follow redirects by default" do


### PR DESCRIPTION
This allows you to set both body parameters (:params) and query
parameters (:query_params) for non-GET requests.

For consistency, GET requests also support :query_params.  If both
:params and :query_params are provided, :params will append to the
existing query before :query_params.

Implements https://github.com/rack/rack-test/issues/150.