### PR TITLE
Deprecate digest authentication support

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -192,6 +192,10 @@ module Rack
       # Example:
       #   digest_authorize "bryan", "secret"
       def digest_authorize(username, password)
+        warn 'digest authentication support will be removed in rack-test 1.3', uplevel: 1
+        _digest_authorize(username, password)
+      end
+      def _digest_authorize(username, password) # :nodoc:
         @digest_username = username
         @digest_password = password
       end
@@ -324,7 +328,7 @@ module Rack
                       'uri'       => last_request.fullpath,
                       'method'    => last_request.env['REQUEST_METHOD'])
 
-        params['response'] = MockDigestRequest.new(params).response(@digest_password)
+        params['response'] = MockDigestRequest_.new(params).response(@digest_password)
 
         "Digest #{params}"
       end

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -55,6 +55,11 @@ module Rack
         @_current_session_names ||= [:default]
       end
 
+      def digest_authorize(username, password)
+        warn 'digest authentication support will be removed in rack-test 1.3', uplevel: 1
+        current_session._digest_authorize(username, password)
+      end
+
       METHODS = %i[
         request
         get
@@ -72,7 +77,6 @@ module Rack
         clear_cookies
         authorize
         basic_authorize
-        digest_authorize
         last_response
         last_request
       ].freeze

--- a/lib/rack/test/mock_digest_request.rb
+++ b/lib/rack/test/mock_digest_request.rb
@@ -4,7 +4,7 @@ require 'rack/auth/digest' unless defined?(Rack::Auth::Digest)
 
 module Rack
   module Test
-    class MockDigestRequest # :nodoc:
+    class MockDigestRequest_ # :nodoc:
       def initialize(params)
         @params = params
       end
@@ -25,5 +25,7 @@ module Rack
         Rack::Auth::Digest::MD5.new(nil).send :digest, self, password
       end
     end
+    MockDigestRequest = MockDigestRequest_
+    deprecate_constant :MockDigestRequest if respond_to?(:deprecate_constant, true)
   end
 end

--- a/spec/rack/test/digest_auth_spec.rb
+++ b/spec/rack/test/digest_auth_spec.rb
@@ -9,7 +9,7 @@ describe 'Rack::Test::Session digest authentication' do
   app.opaque = 'this-should-be-secret'
   define_method(:app) { app }
 
-  it 'incorrectly authenticates GETs' do
+  deprecated 'incorrectly authenticates GETs' do
     digest_authorize 'foo', 'bar'
     get '/'
     last_response.status.must_equal 401
@@ -17,22 +17,22 @@ describe 'Rack::Test::Session digest authentication' do
     last_response.body.must_be_empty
   end
 
-  it 'correctly authenticates GETs' do
+  deprecated 'correctly authenticates GETs' do
     digest_authorize 'alice', 'correct-password'
     get('/').must_be :ok?
   end
 
-  it 'correctly authenticates GETs with params' do
+  deprecated 'correctly authenticates GETs with params' do
     digest_authorize 'alice', 'correct-password'
     get('/', 'foo' => 'bar').must_be :ok?
   end
 
-  it 'correctly authenticates POSTs' do
+  deprecated 'correctly authenticates POSTs' do
     digest_authorize 'alice', 'correct-password'
     post('/').must_be :ok?
   end
 
-  it 'returns a re-challenge if authenticating incorrectly' do
+  deprecated 'returns a re-challenge if authenticating incorrectly' do
     digest_authorize 'alice', 'incorrect-password'
     get '/'
     last_response.status.must_equal 401
@@ -42,11 +42,11 @@ describe 'Rack::Test::Session digest authentication' do
 end
 
 describe 'Rack::Test::MockDigestRequest' do
-  it '#method_missing will return values based on params if they are present' do
+  deprecated '#method_missing will return values based on params if they are present' do
     Rack::Test::MockDigestRequest.new('foo' => 'bar').foo.must_equal 'bar'
   end
 
-  it '#method_missing will raise NoMethodError if param is not present' do
+  deprecated '#method_missing will raise NoMethodError if param is not present' do
     proc{Rack::Test::MockDigestRequest.new({}).foo}.must_raise NoMethodError
   end
 end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -390,29 +390,30 @@ describe 'Rack::Test::Session#digest_authorize' do
 
   define_method(:app){digest_app}
 
-  before do
+  def request
     digest_authorize('test-name', 'test-password')
-    request('/')
+    super('/')
+    last_request
   end
 
-  it 'retries digest requests' do
-    last_request.env['rack-test.digest_auth_retry'].must_equal true
+  deprecated 'retries digest requests' do
+    request.env['rack-test.digest_auth_retry'].must_equal true
   end
 
-  it 'sends a digest auth header' do
-    last_request.env['HTTP_AUTHORIZATION'].must_include 'Digest realm'
+  deprecated 'sends a digest auth header' do
+    request.env['HTTP_AUTHORIZATION'].must_include 'Digest realm'
   end
 
-  it 'includes the response based on the username,password and nonce' do
-    last_request.env['HTTP_AUTHORIZATION'].must_include 'response="d773034bdc162b31c50c62764016bd31"'
+  deprecated 'includes the response based on the username,password and nonce' do
+    request.env['HTTP_AUTHORIZATION'].must_include 'response="d773034bdc162b31c50c62764016bd31"'
   end
 
-  it 'includes the challenge headers' do
-    last_request.env['HTTP_AUTHORIZATION'].must_include challenge_data
+  deprecated 'includes the challenge headers' do
+    request.env['HTTP_AUTHORIZATION'].must_include challenge_data
   end
 
-  it 'includes the username' do
-    last_request.env['HTTP_AUTHORIZATION'].must_include 'username="test-name"'
+  deprecated 'includes the username' do
+    request.env['HTTP_AUTHORIZATION'].must_include 'username="test-name"'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,15 @@ class Minitest::Spec
   def app
     Rack::Test::FAKE_APP
   end
+
+  def self.deprecated(*args, &block)
+    it(*args) do
+      begin
+        verbose, $VERBOSE = $VERBOSE, nil
+        instance_exec(&block)
+      ensure
+        $VERBOSE = verbose
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is being deprecated in Rack 3, and rack-test relies on the
Rack implementation, so it needs to be deprecated and then
removed from rack-test.

This deprecates direct access to the constant, as well as
provides appropriate warning messages for calling
digest_authorize both directly on the session and through the
delegator.