### PR TITLE
Don't set HTTP_VERSION in Rack 3

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -215,8 +215,13 @@ module Rack
         'rack.test' => true,
         'REMOTE_ADDR' => '127.0.0.1',
         'SERVER_PROTOCOL' => 'HTTP/1.0',
-        'HTTP_VERSION' => 'HTTP/1.0'
-      }.freeze
+      }
+      # :nocov:
+      unless Rack.release >= '2.3'
+        DEFAULT_ENV['HTTP_VERSION'] = DEFAULT_ENV['SERVER_PROTOCOL']
+      end
+      # :nocov:
+      DEFAULT_ENV.freeze
       private_constant :DEFAULT_ENV
 
       # Update environment to use based on given URI.

--- a/lib/rack/test/mock_digest_request.rb
+++ b/lib/rack/test/mock_digest_request.rb
@@ -26,6 +26,8 @@ module Rack
       end
     end
     MockDigestRequest = MockDigestRequest_
+    # :nocov:
     deprecate_constant :MockDigestRequest if respond_to?(:deprecate_constant, true)
+    # :nocov:
   end
 end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -396,6 +396,12 @@ describe 'Rack::Test::Session#digest_authorize' do
     last_request
   end
 
+  deprecated 'is defined directly on the session' do
+    current_session.digest_authorize('test-name', 'test-password')
+    get('/')
+    last_request.env['rack-test.digest_auth_retry'].must_equal true
+  end
+
   deprecated 'retries digest requests' do
     request.env['rack-test.digest_auth_retry'].must_equal true
   end


### PR DESCRIPTION
Also, get back to 100% coverage after digest auth deprecation.