### PR TITLE
Improve performance of Utils.build_multipart and .build_nested_query

### DIFF
--- a/History.md
+++ b/History.md
@@ -23,6 +23,9 @@
     (Jeremy Evans #297)
   * Headers used/accessed by rack-test are now lower case, for rack 3
     compliance (Jeremy Evans #295)
+  * Frozen literal strings are now used internally, which may break
+    code that mutates static strings returned by rack-test, if any
+    (Jeremy Evans #304)
 
 * Minor enhancements:
   * rack-test now works with the rack main branch (what will be rack 3)
@@ -41,6 +44,14 @@
     body (Jeremy Evans #150 #287)
   * Reduce required ruby version to 2.0, since tests run fine on
     Ruby 2.0 (Jeremy Evans #292)
+  * Support :multipart env key for request methods to force multipart
+    input (Jeremy Evans #303)
+  * Force multipart input for request methods if content type starts
+    with multipart (Jeremy Evans #303)
+  * Improve performance of Utils.build_multipart by using an
+    append-only design (Jeremy Evans #304)
+  * Improve performance of Utils.build_nested_query for array values
+    (Jeremy Evans #304)
 
 * Bug fixes:
   * The `CONTENT_TYPE` of multipart requests is now respected, if it

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require 'uri'
 
 # :nocov:

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'uri'
 

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -35,6 +35,12 @@ module Rack
     # The default multipart boundary to use for multipart request bodies
     MULTIPART_BOUNDARY = '----------XnJLe9ZIbbGUYtzPQJ16u1'.freeze
 
+    # The starting boundary in multipart requests
+    START_BOUNDARY = "--#{MULTIPART_BOUNDARY}\r\n".freeze
+
+    # The ending boundary in multipart requests
+    END_BOUNDARY = "--#{MULTIPART_BOUNDARY}--\r\n".freeze
+
     # The common base class for exceptions raised by Rack::Test
     class Error < StandardError; end
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require 'uri'
 require 'time'
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'uri'
 require 'time'

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'forwardable'
 

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require 'forwardable'
 
 module Rack

--- a/lib/rack/test/mock_digest_request.rb
+++ b/lib/rack/test/mock_digest_request.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 # :nocov:
 require 'rack/auth/digest' unless defined?(Rack::Auth::Digest)

--- a/lib/rack/test/mock_digest_request.rb
+++ b/lib/rack/test/mock_digest_request.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 # :nocov:
 require 'rack/auth/digest' unless defined?(Rack::Auth::Digest)
 # :nocov:

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'fileutils'
 require 'tempfile'

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require 'fileutils'
 require 'tempfile'
 require 'stringio'

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -14,8 +14,8 @@ module Rack
           if value.empty?
             "#{prefix}[]="
           else
+            prefix += "[]" unless unescape(prefix).end_with?('[]')
             value.map do |v|
-              prefix = "#{prefix}[]" unless unescape(prefix) =~ /\[\]$/
               build_nested_query(v, prefix.to_s)
             end.join('&')
           end

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 module Rack
   module Test
     module Utils # :nodoc:

--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 module Rack
   module Test

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 describe Rack::Test::CookieJar do

--- a/spec/rack/test/cookie_object_spec.rb
+++ b/spec/rack/test/cookie_object_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 require 'cgi'
 

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 describe "Rack::Test::Session" do

--- a/spec/rack/test/digest_auth_spec.rb
+++ b/spec/rack/test/digest_auth_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 require_relative '../../../lib/rack/test/mock_digest_request'
 

--- a/spec/rack/test/methods_spec.rb
+++ b/spec/rack/test/methods_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 describe 'Rack::Test::Methods' do

--- a/spec/rack/test/multipart_spec.rb
+++ b/spec/rack/test/multipart_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 uploaded_files = Module.new do

--- a/spec/rack/test/uploaded_file_spec.rb
+++ b/spec/rack/test/uploaded_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 describe Rack::Test::UploadedFile do

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../../spec_helper'
 
 describe "Rack::Test::Utils#build_nested_query" do

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 require_relative '../spec_helper'
 
 describe 'Rack::Test::Session' do


### PR DESCRIPTION
Switch to frozen string literals.

Improve build_multipart using an append-only design.

Improve build_nested_query for array values by moving code out of the loop.