### PR TITLE
Add Session#restore_state for restoring previous state after block execution

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,14 @@
   * requiring rack/mock_session, deprecated in 2.0.0, has been removed
     (Jeremy Evans #307)
 
+* Minor enhancements:
+  * The `original_filename` for `Rack::Test::UploadedFile` can now be
+    set even if the content of the file comes from a file path
+    (Stuart Chinery #314)
+  * Add `Rack::Test::Session#restore_state`, for executing a block
+    and restoring current state (last request, last response, and
+    cookies) after the block. (Jeremy Evans #316)
+
 ## 2.0.2 / 2022-06-28
 
 * Bug fixes:

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -234,6 +234,23 @@ module Rack
         )
       end
 
+      # Yield to the block, and restore the last request, last response, and
+      # cookie jar to the state they were prior to block execution upon
+      # exiting the block.
+      def restore_state
+        request = @last_request
+        response = @last_response
+        cookie_jar = @cookie_jar.dup
+
+        begin
+          yield
+        ensure
+          @last_request = request
+          @last_response = response
+          @cookie_jar = cookie_jar
+        end
+      end
+
       private
 
       # :nocov:

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -241,6 +241,7 @@ module Rack
         request = @last_request
         response = @last_response
         cookie_jar = @cookie_jar.dup
+        after_request = @after_request.dup
 
         begin
           yield
@@ -248,6 +249,7 @@ module Rack
           @last_request = request
           @last_response = response
           @cookie_jar = cookie_jar
+          @after_request = after_request
         end
       end
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -138,6 +138,12 @@ module Rack
         @cookies = cookies.sort!
       end
 
+      # Ensure the copy uses a distinct cookies array.
+      def initialize_copy(other)
+        super
+        @cookies = @cookies.dup
+      end
+
       # Return the value for first cookie with the given name, or nil
       # if no such cookie exists.
       def [](name)

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -6,6 +6,17 @@ describe Rack::Test::CookieJar do
   cookie_value = 'foo;abc'.freeze
   cookie_name = 'a_cookie_name'.freeze
 
+  it 'copies should not share a cookie jar' do
+    jar = Rack::Test::CookieJar.new
+    jar_dup = jar.dup
+    jar_clone = jar.clone
+
+    jar['a'] = 'b'
+    jar.to_hash.must_equal 'a' => 'b'
+    jar_dup.to_hash.must_be_empty
+    jar_clone.to_hash.must_be_empty
+  end
+
   it '#[] and []= should get and set cookie values' do
     jar = Rack::Test::CookieJar.new
     jar[cookie_name].must_be_nil

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -796,3 +796,24 @@ describe 'Rack::Test::Session#custom_request' do
     last_request.must_be :xhr?
   end
 end
+
+describe 'Rack::Test::Session#restore_state' do
+  it 'restores last request and response after block' do
+    get('/')
+    request = last_request
+    response = last_response
+    current_session.cookie_jar['simple'].must_be_nil
+
+    current_session.restore_state do
+      get('/cookies/set-simple?value=foo')
+      current_session.cookie_jar['simple'].must_equal 'foo'
+
+      last_request.wont_be_same_as request
+      last_response.wont_be_same_as response
+    end
+
+    last_request.must_be_same_as request
+    last_response.must_be_same_as response
+    current_session.cookie_jar['simple'].must_be_nil
+  end
+end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -798,22 +798,31 @@ describe 'Rack::Test::Session#custom_request' do
 end
 
 describe 'Rack::Test::Session#restore_state' do
-  it 'restores last request and response after block' do
+  it 'restores last request, last response, cookies, and hooks after block' do
+    after_request = []
+    current_session.after_request{after_request << 1}
+
     get('/')
     request = last_request
     response = last_response
     current_session.cookie_jar['simple'].must_be_nil
+    after_request.must_equal [1]
 
     current_session.restore_state do
+      current_session.after_request{after_request << 2}
       get('/cookies/set-simple?value=foo')
       current_session.cookie_jar['simple'].must_equal 'foo'
 
       last_request.wont_be_same_as request
       last_response.wont_be_same_as response
+      after_request.must_equal [1, 1, 2]
     end
 
     last_request.must_be_same_as request
     last_response.must_be_same_as response
     current_session.cookie_jar['simple'].must_be_nil
+
+    get('/')
+    after_request.must_equal [1, 1, 2, 1]
   end
 end


### PR DESCRIPTION
This type of API is very helpful for testing access control in
applications.  I currently do something similar in the
capybara-restore_state gem, but that reaches into rack-test
internals, and I would like to have a public API for this so it
isn't necessary to do so.