### PR TITLE
add Rack::Test.default_host= to change the default_host more easily.

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -30,7 +30,14 @@ module Rack
   module Test
     # The default host to use for requests, when a full URI is not
     # provided.
-    DEFAULT_HOST = 'example.org'.freeze
+    def self.default_host
+      @@default_host ||= 'example.org'.freeze
+    end
+
+    # Sets the default host used when a full URI is not provided.
+    def self.default_host=(host)
+      @@default_host = host.freeze
+    end
 
     # The default multipart boundary to use for multipart request bodies
     MULTIPART_BOUNDARY = '----------XnJLe9ZIbbGUYtzPQJ16u1'.freeze
@@ -54,7 +61,7 @@ module Rack
       extend Forwardable
       include Rack::Test::Utils
 
-      def self.new(app, default_host = DEFAULT_HOST) # :nodoc:
+      def self.new(app, default_host = Rack::Test.default_host) # :nodoc:
         if app.is_a?(self)
           # Backwards compatibility for initializing with Rack::MockSession
           app
@@ -96,7 +103,7 @@ module Rack
       # submitted in #last_request. The methods store a Rack::MockResponse based on the
       # response in #last_response. #last_response is also returned by the methods.
       # If a block is given, #last_response is also yielded to the block.
-      def initialize(app, default_host = DEFAULT_HOST)
+      def initialize(app, default_host = Rack::Test.default_host)
         @env = {}
         @app = app
         @after_request = []

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -20,7 +20,7 @@ module Rack
       # name=value format is name and value are provided.
       attr_reader :raw
 
-      def initialize(raw, uri = nil, default_host = DEFAULT_HOST)
+      def initialize(raw, uri = nil, default_host = Rack::Test.default_host)
         @default_host = default_host
         uri ||= default_uri
 
@@ -133,7 +133,7 @@ module Rack
     class CookieJar # :nodoc:
       DELIMITER = '; '.freeze
 
-      def initialize(cookies = [], default_host = DEFAULT_HOST)
+      def initialize(cookies = [], default_host = Rack::Test.default_host)
         @default_host = default_host
         @cookies = cookies.sort!
       end

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -73,6 +73,13 @@ describe 'Rack::Test::Session#request' do
     last_request.env['SERVER_NAME'].must_equal 'example.org'
   end
 
+  it 'default_host can be changed' do
+    Rack::Test.default_host = 'rack.github.io'
+    request '/'
+    last_request.env['SERVER_NAME'].must_equal 'rack.github.io'
+    Rack::Test.default_host = 'example.org'
+  end
+
   it 'yields the response to a given block' do
     request '/' do |response|
       response.must_be :ok?


### PR DESCRIPTION
As with the people in #15 AND #239 I was having issues setting/changing the DEFAULT_HOST.

Current work around is ugly:
```
require 'rack/test'
Rack::Test::DEFAULT_HOST='sub.example.org'
```

My tests have to check the app changes databases based on the subdomain, so an easy way to change the default host makes my tests much easier to read.
