### PR TITLE
Support default_host in Rack::Test::Methods

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,9 @@
   * Add `Rack::Test::Session#restore_state`, for executing a block
     and restoring current state (last request, last response, and
     cookies) after the block. (Jeremy Evans #316)
+  * Make `Rack::Test::Methods` support `default_host` method similar to
+    `app`, which will set the default host used for requests to the app.
+    (Jeremy Evans #317 #318)
 
 ## 2.0.2 / 2022-06-28
 

--- a/lib/rack/test/methods.rb
+++ b/lib/rack/test/methods.rb
@@ -42,7 +42,11 @@ module Rack
           # Backwards compatibility for capybara
           build_rack_mock_session
         else
-          Session.new(app)
+          if respond_to?(:default_host)
+            Session.new(app, default_host)
+          else
+            Session.new(app)
+          end
         end
       end
 

--- a/spec/rack/test/methods_spec.rb
+++ b/spec/rack/test/methods_spec.rb
@@ -28,4 +28,25 @@ describe 'Rack::Test::Methods' do
     define_singleton_method(:build_rack_mock_session){session}
     current_session.must_be_same_as session
   end
+
+  it '#build_rack_test_session will use defined app' do
+    envs = []
+    app = proc{|env| envs << env; [200, {}, []]}
+    define_singleton_method(:app){app}
+
+    get '/'
+    envs.first['PATH_INFO'].must_equal '/'
+    envs.first['HTTP_HOST'].must_equal 'example.org'
+  end
+
+  it '#build_rack_test_session will use defined default_host' do
+    envs = []
+    app = proc{|env| envs << env; [200, {}, []]}
+    define_singleton_method(:app){app}
+    define_singleton_method(:default_host){'foo.example.com'}
+
+    get '/'
+    envs.first['PATH_INFO'].must_equal '/'
+    envs.first['HTTP_HOST'].must_equal 'foo.example.com'
+  end
 end


### PR DESCRIPTION
This allows you to configure a default host the same way you
configure the application.

Fixes #317