### PR TITLE
gemspec, spec_helper: drop unnecessary require_relative

### DIFF
--- a/rack-test.gemspec
+++ b/rack-test.gemspec
@@ -1,4 +1,5 @@
-require_relative 'lib/rack/test/version'
+$:.unshift(File.expand_path("lib", File.dirname(__FILE__)))
+require 'rack/test/version'
 
 Gem::Specification.new do |s|
   s.name = 'rack-test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ ENV['MT_NO_PLUGINS'] = '1' # Work around stupid autoloading of plugins
 gem 'minitest'
 require 'minitest/global_expectations/autorun'
 
-require_relative '../lib/rack/test'
+require 'rack/test'
 require_relative 'fixtures/fake_app'
 
 class Minitest::Spec


### PR DESCRIPTION
The first line of `spec/spec_helper.rb` already adds the local lib/
directory to the Ruby load path, so this explicit require relative is
not really needed. For rack-test.gemspec, add lib/ to the load path.

Dropping the require_relative pointing into the local lib/ directory
allows us to run the test suite against the files installed system-wide,
and that's an important QA tool for Debian.