### PR TITLE
Don't add lib to the load path when running specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-$:.unshift(File.expand_path("../lib", File.dirname(__FILE__)))
-
 if ENV.delete('COVERAGE')
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
This isn't needed, and it's helpful to ensure that the internals
are using require_relative instead of require.