### PR TITLE
Only check Cookie paths when sending requests

### DIFF
--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -60,6 +60,10 @@ module Rack
           end
         end
 
+        if path == '/redirect-with-cookie' && method == 'GET'
+          return [302, { 'set-cookie' => "value=1; path=/cookies;", 'location' => '/cookies/show' }, []]
+        end
+
         if path == '/redirected'
           additional_info = if method == 'GET'
             ", session #{session.inspect} with options #{env['rack.session.options'].inspect}"

--- a/spec/rack/test/cookie_object_spec.rb
+++ b/spec/rack/test/cookie_object_spec.rb
@@ -7,7 +7,7 @@ describe Rack::Test::Cookie do
   value = 'the cookie value'.freeze
   domain = 'www.example.org'.freeze
   path = '/foo'.freeze
-  expires = 'Mon, 10 Aug 2015 14:40:57 0100'.freeze
+  expires = (Time.now + (24 * 60 * 60)).httpdate
   cookie_string = [
       'cookie_name=' + CGI.escape(value),
       'domain=' + domain,
@@ -39,20 +39,20 @@ describe Rack::Test::Cookie do
     Rack::Test::Cookie.new('value=').empty?.must_equal true
   end
 
-  it '#valid_set? should consider the given URI scheme for secure cookies' do
-    cookie('; secure').valid_set?(URI.parse('https://www.example.org/')).must_equal true
-    cookie('; secure').valid_set?(URI.parse('httpx://www.example.org/')).must_equal false
-    cookie('; secure').valid_set?(URI.parse('/')).must_equal false
+  it '#valid? should consider the given URI scheme for secure cookies' do
+    cookie('; secure').valid?(URI.parse('https://www.example.org/')).must_equal true
+    cookie('; secure').valid?(URI.parse('httpx://www.example.org/')).must_equal false
+    cookie('; secure').valid?(URI.parse('/')).must_equal false
   end
 
-  it '#valid_set? is indifferent to matching paths' do
-    cookie.valid_set?(URI.parse('https://www.example.org/foo')).must_equal true
-    cookie.valid_set?(URI.parse('https://www.example.org/bar')).must_equal true
+  it '#valid? is indifferent to matching paths' do
+    cookie.valid?(URI.parse('https://www.example.org/foo')).must_equal true
+    cookie.valid?(URI.parse('https://www.example.org/bar')).must_equal true
   end
 
-  it '#valid_send? demands matching paths' do
-    cookie.valid_send?(URI.parse('https://www.example.org/foo')).must_equal true
-    cookie.valid_send?(URI.parse('https://www.example.org/bar')).must_equal false
+  it '#matches? demands matching paths' do
+    cookie.matches?(URI.parse('https://www.example.org/foo')).must_equal true
+    cookie.matches?(URI.parse('https://www.example.org/bar')).must_equal false
   end
 
   it '#http_only? for a non HTTP only cookie returns false' do

--- a/spec/rack/test/cookie_object_spec.rb
+++ b/spec/rack/test/cookie_object_spec.rb
@@ -6,7 +6,7 @@ require 'cgi'
 describe Rack::Test::Cookie do
   value = 'the cookie value'.freeze
   domain = 'www.example.org'.freeze
-  path = '/'.freeze
+  path = '/foo'.freeze
   expires = 'Mon, 10 Aug 2015 14:40:57 0100'.freeze
   cookie_string = [
       'cookie_name=' + CGI.escape(value),
@@ -39,10 +39,20 @@ describe Rack::Test::Cookie do
     Rack::Test::Cookie.new('value=').empty?.must_equal true
   end
 
-  it '#valid? should consider the given URI scheme for secure cookies' do
-    cookie('; secure').valid?(URI.parse('https://www.example.org/')).must_equal true
-    cookie('; secure').valid?(URI.parse('httpx://www.example.org/')).must_equal false
-    cookie('; secure').valid?(URI.parse('/')).must_equal false
+  it '#valid_set? should consider the given URI scheme for secure cookies' do
+    cookie('; secure').valid_set?(URI.parse('https://www.example.org/')).must_equal true
+    cookie('; secure').valid_set?(URI.parse('httpx://www.example.org/')).must_equal false
+    cookie('; secure').valid_set?(URI.parse('/')).must_equal false
+  end
+
+  it '#valid_set? is indifferent to matching paths' do
+    cookie.valid_set?(URI.parse('https://www.example.org/foo')).must_equal true
+    cookie.valid_set?(URI.parse('https://www.example.org/bar')).must_equal true
+  end
+
+  it '#valid_send? demands matching paths' do
+    cookie.valid_send?(URI.parse('https://www.example.org/foo')).must_equal true
+    cookie.valid_send?(URI.parse('https://www.example.org/bar')).must_equal false
   end
 
   it '#http_only? for a non HTTP only cookie returns false' do

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -258,4 +258,10 @@ describe "Rack::Test::Session" do
     request '/cookies/show', cookie: 'value=1'
     last_request.cookies.must_equal 'value' => '1'
   end
+
+  it 'sets and subsequently sends cookies when redirecting to the path of the cookie' do
+    get '/redirect-with-cookie'
+    follow_redirect!
+    last_request.cookies.must_equal 'value' => '1'
+  end
 end


### PR DESCRIPTION
Hey wonderful Rack::Test folks 👋 

I come with little open source contribution experience, but plenty of gratitude for the folks that do and positive intent.

This PR aims to resolve a cookie issue where I believe the Rack::Test implementation differs from the cookie specification.

I've done some testing and checked the [spec](https://httpwg.org/specs/rfc6265.html#sane-set-cookie), in these cases it's possible to set a cookie with a path parameter different to the current path of the browser. The cookie will only be sent to the server when the browser makes a request to that path.

> Even though the Set-Cookie header supports the Path attribute, the Path attribute does not provide any integrity protection because the user agent will accept an arbitrary Path attribute in a Set-Cookie header. For example, an HTTP response to a request for http://example.com/foo/bar can set a cookie with a Path attribute of "/qux".

The above is taken from https://httpwg.org/specs/rfc6265.html#rfc.section.8.6

In the current implementation of Rack::Test the same `valid?` method is performed when setting and sending cookies. The validity rules should differ; the path validity can be ignored when setting cookies.

This PR is an attempt to demonstrate the problem, double check on my interpretation of the spec, and propose a solution.

Thanks in advance for your time.