### PR TITLE
swap arguments for `assert_equal` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class HomepageTest < Test::Unit::TestCase
     get '/'
 
     assert last_response.ok?
-    assert_equal last_response.body, 'All responses are OK'
+    assert_equal 'All responses are OK', last_response.body
   end
 
   def delete_with_url_params_and_body


### PR DESCRIPTION
Hello 👋 

I just came across this tiny little detail in the README, where the example says:

```ruby
assert_equal last_response.body, 'All responses are OK'
```

I think the two arguments should be swapped, since the signature for Minitest's `assert_equal` is 

```ruby
def assert_equal(exp, act, msg = nil)
```

https://github.com/minitest/minitest/blob/b5565c0c7ab2ce5ecf306487cab0f2abe5377d55/lib/minitest/assertions.rb#L216
