### PR TITLE
Ignore leading dot when merging cookies

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -32,6 +32,7 @@ module Rack
 
         if @options['domain']
           @exact_domain_match = false
+          @options['domain'].sub!(/^\./, '')
         else
           # If the domain attribute is not present in the cookie,
           # the domain must match exactly.

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -30,7 +30,7 @@ module Rack
         @name, @value = parse_query(@raw, ';').to_a.first
         @options = parse_query(options, ';')
 
-        if @options['domain']
+        if domain = @options['domain']
           @exact_domain_match = false
           domain[0] = '' if domain[0] == '.'
         else

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -32,7 +32,7 @@ module Rack
 
         if @options['domain']
           @exact_domain_match = false
-          @options['domain'].sub!(/^\./, '')
+          domain[0] = '' if domain[0] == '.'
         else
           # If the domain attribute is not present in the cookie,
           # the domain must match exactly.

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -61,4 +61,12 @@ describe Rack::Test::CookieJar do
     jar.merge('c=d; domain=example.org; secure', URI.parse('/'))
     jar.to_hash.must_equal 'a' => 'b'
   end
+
+  it '#merge merges cookie strings where domains differ by leading dot' do
+    jar = Rack::Test::CookieJar.new
+    jar << Rack::Test::Cookie.new('a=b; domain=lithostech.com', URI('https://lithostech.com'))
+    jar << Rack::Test::Cookie.new('a=c; domain=.lithostech.com', URI('https://lithostech.com'))
+
+    jar.to_hash.must_equal 'a' => 'c'
+  end
 end

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -17,6 +17,12 @@ describe Rack::Test::CookieJar do
     jar_clone.to_hash.must_be_empty
   end
 
+  it 'ignores leading dot in domain' do
+    jar = Rack::Test::CookieJar.new
+    jar << Rack::Test::Cookie.new('a=c; domain=.lithostech.com', URI('https://lithostech.com'))
+    jar.get_cookie('a').domain.must_equal 'lithostech.com'
+  end
+
   it '#[] and []= should get and set cookie values' do
     jar = Rack::Test::CookieJar.new
     jar[cookie_name].must_be_nil
@@ -60,13 +66,5 @@ describe Rack::Test::CookieJar do
     jar['a'] = 'b'
     jar.merge('c=d; domain=example.org; secure', URI.parse('/'))
     jar.to_hash.must_equal 'a' => 'b'
-  end
-
-  it '#merge merges cookie strings where domains differ by leading dot' do
-    jar = Rack::Test::CookieJar.new
-    jar << Rack::Test::Cookie.new('a=b; domain=lithostech.com', URI('https://lithostech.com'))
-    jar << Rack::Test::Cookie.new('a=c; domain=.lithostech.com', URI('https://lithostech.com'))
-
-    jar.to_hash.must_equal 'a' => 'c'
   end
 end


### PR DESCRIPTION
Most recent specification states that leading dots are ignored by user agents: https://httpwg.org/specs/rfc6265.html#sane-domain

Rails in particular likes to add a leading dot: https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/cookies.rb#L473

This PR allows us to manually set a cookie with rack-test and use the default domain, then test that a Rails controller action deletes that cookie.