### PR TITLE
Skip multipart body if request params is empty

### DIFF
--- a/lib/rack/test/utils.rb
+++ b/lib/rack/test/utils.rb
@@ -33,6 +33,7 @@ module Rack
       # Build a multipart body for the given params.
       def build_multipart(params, _first = true, multipart = false)
         raise ArgumentError, 'value must be a Hash' unless params.is_a?(Hash)
+        return nil if params.empty?
 
         unless multipart
           query = lambda { |value|

--- a/spec/rack/test/utils_spec.rb
+++ b/spec/rack/test/utils_spec.rb
@@ -294,6 +294,10 @@ describe 'Rack::Test::Utils.build_multipart' do
     end.must_raise(ArgumentError, 'value must be a Hash')
   end
 
+  it 'returns nil if params is empty' do
+    Rack::Test::Utils.build_multipart({}).must_be_nil
+  end
+
   def multipart_file(name)
     File.join(File.dirname(__FILE__), '..', '..', 'fixtures', name.to_s)
   end


### PR DESCRIPTION
When request params is empty, request body is multipart boundary without data. This is meaningless, and it raises a `Rack::EmptyContentError`. https://github.com/rack/rack/blob/v3.0.4.1/lib/rack/multipart/parser.rb#L415-L419