### PR TITLE
Don't raise error with empty params and multipart header

### DIFF
--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -312,7 +312,7 @@ module Rack
           multipart = env.has_key?(:multipart) ? env.delete(:multipart) : env['CONTENT_TYPE'].start_with?('multipart/')
 
           if params.is_a?(Hash)
-            if data = build_multipart(params, false, multipart)
+            if !params.empty? && data = build_multipart(params, false, multipart)
               env[:input] = data
               env['CONTENT_LENGTH'] ||= data.length.to_s
               env['CONTENT_TYPE'] = "#{multipart_content_type(env)}; boundary=#{MULTIPART_BOUNDARY}"

--- a/spec/rack/test_spec.rb
+++ b/spec/rack/test_spec.rb
@@ -121,6 +121,13 @@ describe 'Rack::Test::Session#request' do
     last_request.env['rack.input'].read.must_include 'content-disposition: form-data; name="foo"'
   end
 
+  it 'supports multipart CONTENT_TYPE when using empty :params for POST to be empty body' do
+    request '/', method: :post, params: {}, 'CONTENT_TYPE'=>'multipart/form-data'
+    last_request.POST.must_be_empty
+    last_request.env['rack.input'].rewind
+    last_request.env['rack.input'].read.must_be_empty
+  end
+
   it 'supports sending :query_params for POST' do
     request '/', method: :post, query_params: { 'foo' => 'bar' }
     last_request.GET['foo'].must_equal 'bar'


### PR DESCRIPTION
POST request with empty params and multipart header raises a `Rack::EmptyContentError` since 5b4bbfff166fc7c92ea9f33dc181c393ebeee96c.
https://github.com/rack/rack/blob/v3.0.4.1/lib/rack/multipart/parser.rb#L415-L419