### PR TITLE
Prefer Dir.glob with block over Dir#[] + #each

### DIFF
--- a/spec/all.rb
+++ b/spec/all.rb
@@ -1,1 +1,1 @@
-Dir['spec/**/*_spec.rb'].each{|f| require_relative f.sub('spec/', '')}
+Dir.glob('spec/**/*_spec.rb') {|f| require_relative f.sub('spec/', '')}


### PR DESCRIPTION
This refactors to use the "pass a block" feature of Dir.glob, instead of the "shorthand" Dir#[].

I looked at the Ruby 1.9.3 docs, to verify this usage was supported then, and it was. (`Dir#[]` uses `rb_push_glob` in its implementation.)