### PR TITLE
Remove use of finalizer in Rack::Test::UploadedFile (Fixes #338)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+## main
+
+* Minor enhancements:
+  * `Rack::Test::UploadedFile` no longer uses a finalizer for named
+    paths to close and unlink the created Tempfile.  Tempfile itself
+    uses a finalizer to close and unlink itself, so there is no
+    reason for `Rack::Test::UploadedFile` to do so (Jeremy Evans #338)
+
 ## 2.1.0 / 2023-03-14
 
 * Breaking changes:

--- a/lib/rack/test/uploaded_file.rb
+++ b/lib/rack/test/uploaded_file.rb
@@ -72,18 +72,6 @@ module Rack
         tempfile.respond_to?(method_name, include_private) || super
       end
 
-      # A proc that can be used as a finalizer to close and unlink the tempfile.
-      def self.finalize(file)
-        proc { actually_finalize file }
-      end
-
-      # Close and unlink the given file, used as a finalizer for the tempfile,
-      # if the tempfile is backed by a file in the filesystem.
-      def self.actually_finalize(file)
-        file.close
-        file.unlink
-      end
-
       private
 
       # Use the StringIO as the tempfile.
@@ -103,8 +91,6 @@ module Rack
 
         @tempfile = Tempfile.new([::File.basename(@original_filename, extension), extension])
         @tempfile.set_encoding(Encoding::BINARY)
-
-        ObjectSpace.define_finalizer(self, self.class.finalize(@tempfile))
 
         FileUtils.copy_file(path, @tempfile.path)
       end


### PR DESCRIPTION
A finalizer was used in the Tempfile case to close and unlink the Tempfile created, but it was never needed, because Tempfile defines its own finalizer that closes and unlinks.
    
Update the spec so that it actually tests that tempfiles are getting removed and unlinked. This uses 500 tempfiles in the JRuby test because some lower values I tried failed CI.  CRuby could likely get away with only a handle of tempfiles, but the spec uses 50 to be sure it doesn't fail.