### PR TITLE
Fix array of cookies in response containing a blank cookie

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -12,7 +12,7 @@ module Rack
 
       # The name of the cookie, will be a string
       attr_reader :name
-      
+
       # The value of the cookie, will be a string or nil if there is no value.
       attr_reader :value
 
@@ -183,12 +183,10 @@ module Rack
       def merge(raw_cookies, uri = nil)
         return unless raw_cookies
 
-        if raw_cookies.is_a? String
-          raw_cookies = raw_cookies.split("\n")
-          raw_cookies.reject!(&:empty?)
-        end
+        raw_cookies = raw_cookies.split("\n") if raw_cookies.is_a? String
 
         raw_cookies.each do |raw_cookie|
+          next if raw_cookie.empty?
           cookie = Cookie.new(raw_cookie, uri, @default_host)
           self << cookie if cookie.valid?(uri)
         end

--- a/spec/rack/test/cookie_jar_spec.rb
+++ b/spec/rack/test/cookie_jar_spec.rb
@@ -67,4 +67,17 @@ describe Rack::Test::CookieJar do
     jar.merge('c=d; domain=example.org; secure', URI.parse('/'))
     jar.to_hash.must_equal 'a' => 'b'
   end
+
+  it '#merge ignores empty cookies in cookie strings' do
+    jar = Rack::Test::CookieJar.new
+    jar.merge('', URI.parse('/'))
+    jar.merge("\nc=d")
+    jar.to_hash.must_equal 'c' => 'd'
+  end
+
+  it '#merge ignores empty cookies in cookie arrays' do
+    jar = Rack::Test::CookieJar.new
+    jar.merge(['', 'c=d'], URI.parse('/'))
+    jar.to_hash.must_equal 'c' => 'd'
+  end
 end


### PR DESCRIPTION
Without the fix, the blank cookie is compared and since it has no name the comparison fails on name.downcase. Rather than correct it there, this expands the processing of merged cookies to remove blank cookies not just in strings, but also in arrays.

I altered the way empty cookies are removed from the raw_cookies because a passed array should not be mutable, so we just skip them during iteration now in both cases. This should also save a cycle or two updating the array result of split.

Also, my editor auto-cleaned up some whitespace. Let me know if that's undesirable and I will revert that line.