### PR TITLE
2.2.x is not autoclosing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ if RUBY_VERSION >= '3.1'
   end
   gem 'rack', github: 'rack/rack'
 else
-  gem 'rack', '~> 2.0'
+  gem 'rack', '~> 2.2'
 end

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -256,7 +256,7 @@ module Rack
       private
 
       # :nocov:
-      if !defined?(Rack::RELEASE) || Gem::Version.new(Rack::RELEASE) < Gem::Version.new('3.0')
+      if !defined?(Rack::RELEASE) || Gem::Version.new(Rack::RELEASE) < Gem::Version.new('2.2.2')
         def close_body(body)
           body.close if body.respond_to?(:close)
         end

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -256,7 +256,7 @@ module Rack
       private
 
       # :nocov:
-      if !defined?(Rack::RELEASE) || Gem::Version.new(Rack::RELEASE) < Gem::Version.new('2.2.2')
+      if !defined?(Rack::RELEASE) || Gem::Version.new(Rack::RELEASE) < Gem::Version.new('3.0')
         def close_body(body)
           body.close if body.respond_to?(:close)
         end


### PR DESCRIPTION
When testing with `Rack 2.2.8.1`, a number of tests were failing which I tracked down to [this commit](https://github.com/rack/rack-test/commit/d4a45eb1de4cab0e70149a1e5bbcb407f21e8821). Changing this to check if the gem version is less than 3.0 fixes tests. 

I don't see any mention of autoclosing in 2.x branches in Rack's [Changelog](https://github.com/rack/rack/blob/main/CHANGELOG.md).