### PR TITLE
Include rack/builder when rack release is over 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ class TestApp < Test::Unit::TestCase
 end
 ```
 
+When rack version 3.1.8 OUTER_APP should be declared without the `.first`:
+```ruby
+OUTER_APP = Rack::Builder.parse_file("config.ru")
+```
+https://www.rubydoc.info/gems/rack/Rack%2FBuilder.parse_file
+
 ## Install
 
 To install the latest release as a gem:

--- a/lib/rack/test.rb
+++ b/lib/rack/test.rb
@@ -9,6 +9,7 @@ rescue LoadError
   require "rack"
 else
   if Rack.release >= '2.3'
+    require "rack/builder"
     require "rack/request"
     require "rack/mock"
     require "rack/utils"


### PR DESCRIPTION
When updating from rack 2.2.8.1 to rack 3.1.8 in another project I encountered the following errors in my tests:
```

`<top (required)>': uninitialized constant Rack::Builder (NameError)

OUTER_APP = Rack::Builder.parse_file("http://config.ru ").first
```

I added a require to `rack/builder` which made it work, but I think this should be done in the scope of this gem.

This is the first project I contribute to, so am very new to the open source community. So let me know if I missed any steps in the contribution section.

There might be better ways of solving this problem as well, but I figured that instead of writing an issue I'd try solving it in this way and add a PR. In case it is not accepted I'm happy to simply require the dependency in my other project :)