### PR TITLE
fix: cookie-av allows arbitrary casing

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -28,7 +28,7 @@ module Rack
         @raw, options = raw.split(/[;,] */n, 2)
 
         @name, @value = parse_query(@raw, ';').to_a.first
-        @options = parse_query(options, ';')
+        @options = parse_query(options, ';').map { |k, v| [k.downcase, v] }.to_h
 
         if domain = @options['domain']
           @exact_domain_match = false
@@ -69,7 +69,7 @@ module Rack
       # Whether the cookie has the httponly flag, indicating it is not available via
       # a javascript API.
       def http_only?
-        @options.key?('HttpOnly') || @options.key?('httponly')
+        @options.key?('httponly')
       end
 
       # The explicit or implicit path for the cookie.
@@ -110,11 +110,13 @@ module Rack
 
       # A hash of cookie options, including the cookie value, but excluding the cookie name.
       def to_h
-        @options.merge(
+        hash = @options.merge(
           'value'    => @value,
           'HttpOnly' => http_only?,
           'secure'   => secure?
         )
+        hash.delete('httponly')
+        hash
       end
       alias to_hash to_h
 

--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -28,7 +28,7 @@ module Rack
         @raw, options = raw.split(/[;,] */n, 2)
 
         @name, @value = parse_query(@raw, ';').to_a.first
-        @options = parse_query(options, ';').map { |k, v| [k.downcase, v] }.to_h
+        @options = Hash[parse_query(options, ';').map { |k, v| [k.downcase, v] }]
 
         if domain = @options['domain']
           @exact_domain_match = false

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -49,12 +49,28 @@ describe "Rack::Test::Session" do
     cookie_string = [
       '/',
       'csrf_id=ABC123',
-      'path=/',
-      'expires=Wed, 01 Jan 2020 08:00:00 GMT',
+      'path=/cookie',
       'HttpOnly'
     ].join(Rack::Test::CookieJar::DELIMITER)
     cookie = Rack::Test::Cookie.new(cookie_string)
-    cookie.path.must_equal '/'
+    cookie.path.must_equal '/cookie'
+  end
+
+  it 'attribute names are case-insensitive' do
+    cookie_string = [
+      '/',
+      'csrf_id=ABC123',
+      'Path=/cookie',
+      'Expires=Wed, 01 Jan 2020 08:00:00 GMT',
+      'HttpOnly',
+      'Secure',
+    ].join(Rack::Test::CookieJar::DELIMITER)
+    cookie = Rack::Test::Cookie.new(cookie_string)
+
+    cookie.path.must_equal '/cookie'
+    cookie.secure?.must_equal true
+    cookie.http_only?.must_equal true
+    cookie.expires.must_equal Time.parse('Wed, 01 Jan 2020 08:00:00 GMT')
   end
 
   it 'escapes cookie values' do


### PR DESCRIPTION
According to [RFC6265](https://httpwg.org/specs/rfc6265.html#sane-set-cookie), cookie attributes are supposed to be ~PascalCase (`Path`, `HttpOnly`, `Secure`, etc). In practice, browsers are lax in their interpretation of cookie attributes and will allow arbitrary casing (`path`, `Path`, `pAtH`, etc).

Prior to this PR, `Rack::Test::Cookie` only supported lowercased cookie attributes, but this PR allows it to have any casing, making it behave closer to browsers and other cookie jars.

[Python](https://github.com/python/cpython/blob/f0d3f10c43c9029378adba11a65b3d1287e4be32/Lib/http/cookiejar.py#L511-L512)

[Go](https://cs.opensource.google/go/go/+/master:src/net/http/cookie.go;l=126-131;drc=592da0ba474b94b6eceee62b5613f1c9c1ed9c89?q=cookie&ss=go%2Fgo)